### PR TITLE
Moving jenkins runtime scripts to inside the repo.

### DIFF
--- a/deploy/build-test.sh
+++ b/deploy/build-test.sh
@@ -2,8 +2,10 @@
 
 set -e
 
+pushd $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
 godep go build -a github.com/GoogleCloudPlatform/heapster
 
-docker build -t vish/heapster:e2e_test $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-
+docker build -t vish/heapster:e2e_test .
 docker push vish/heapster:e2e_test
+popd

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+pushd $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 godep go build -a github.com/GoogleCloudPlatform/heapster
 
-docker build -t kubernetes/heapster:canary $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+docker build -t kubernetes/heapster:canary .
+popd

--- a/influx-grafana/grafana/build-test.sh
+++ b/influx-grafana/grafana/build-test.sh
@@ -1,4 +1,6 @@
 #! /bin/bash
 
-docker build -t vish/heapster_grafana:e2e_test $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+pushd $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+docker build -t vish/heapster_grafana:e2e_test .
 docker push vish/heapster_grafana:e2e_test
+popd

--- a/influx-grafana/grafana/build.sh
+++ b/influx-grafana/grafana/build.sh
@@ -1,3 +1,5 @@
 #! /bin/bash
 
-docker build -t kubernetes/heapster_grafana:canary $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+pushd $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+docker build -t kubernetes/heapster_grafana:canary .
+popd

--- a/influx-grafana/influxdb/build-test.sh
+++ b/influx-grafana/influxdb/build-test.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
-docker build -t vish/heapster_influxdb:e2e_test $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+pushd $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+docker build -t vish/heapster_influxdb:e2e_test .
 docker push vish/heapster_influxdb:e2e_test
-
+popd

--- a/influx-grafana/influxdb/build.sh
+++ b/influx-grafana/influxdb/build.sh
@@ -1,3 +1,5 @@
 #! /bin/bash
 
-docker build -t kubernetes/heapster_influxdb:canary $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+pushd $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+docker build -t kubernetes/heapster_influxdb:canary
+popd

--- a/integration/.jenkins.sh
+++ b/integration/.jenkins.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -x
+export GOPATH="$JENKINS_HOME/workspace/project"
+export GOBIN="$GOPATH/bin"
+
+deploy/build-test.sh \
+&& influx-grafana/grafana/build-test.sh \
+&& influx-grafana/influxdb/build-test.sh \
+&& pushd integration \
+&& godep go test -a -v --vmodule=*=1 --timeout=30m github.com/GoogleCloudPlatform/heapster/integration/... \
+&& popd


### PR DESCRIPTION
The script will shrink over time and the go tests will take over building and deploying the docker images.