### PR TITLE
Add some debug information to heapster startup.

### DIFF
--- a/sinks/influxdb.go
+++ b/sinks/influxdb.go
@@ -185,6 +185,7 @@ func NewInfluxdbSink() (Sink, error) {
 		Database: *argDbName,
 		IsSecure: false,
 	}
+	glog.Infof("Using influxdb on host %q with database %q", *argDbHost, *argDbName)
 	client, err := influxdb.NewClient(config)
 	if err != nil {
 		return nil, err

--- a/sources/external.go
+++ b/sources/external.go
@@ -33,7 +33,7 @@ type ExternalSource struct {
 func (self *ExternalSource) getCadvisorHosts() (*CadvisorHosts, error) {
 	fi, err := os.Stat(HostsFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot stat hosts_file %q: %s", HostsFile, err)
 	}
 	if fi.Size() == 0 {
 		return &CadvisorHosts{}, nil
@@ -47,6 +47,7 @@ func (self *ExternalSource) getCadvisorHosts() (*CadvisorHosts, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal contents of file %s. Error: %s", HostsFile, err)
 	}
+	glog.Infof("Using cAdvisor hosts %+v", cadvisorHosts)
 	return &cadvisorHosts, nil
 }
 
@@ -74,7 +75,7 @@ func (self *ExternalSource) GetInfo() (ContainerData, error) {
 
 func newExternalSource() (Source, error) {
 	if _, err := os.Stat(HostsFile); err != nil {
-		return nil, fmt.Errorf("Cannot stat hosts_file %s. Error: %s", HostsFile, err)
+		return nil, fmt.Errorf("cannot stat hosts_file %s. Error: %s", HostsFile, err)
 	}
 	cadvisorSource := newCadvisorSource()
 	return &ExternalSource{

--- a/sources/kube.go
+++ b/sources/kube.go
@@ -187,6 +187,10 @@ func newKubeSource() (*KubeSource, error) {
 		Insecure: true,
 	})
 
+	glog.Infof("Using Kubernetes client %+v\n", kubeClient)
+	glog.Infof("Using kubelet port %q", *argKubeletPort)
+	glog.Infof("Support kubelet versions %v", kubeVersions)
+
 	return &KubeSource{
 		client:      kubeClient,
 		lastQuery:   time.Now(),


### PR DESCRIPTION
Ideally, we want to have a validate endpoint for heapster. But we need to expose a port for that.
Not sure if its worth just for debugging info and if there's a lighter solution.