### PR TITLE
Add internal state of heapster to validate endpoint.

### DIFF
--- a/sinks/influxdb.go
+++ b/sinks/influxdb.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/GoogleCloudPlatform/heapster/sources"
@@ -40,6 +41,23 @@ type InfluxdbSink struct {
 	dbName         string
 	bufferDuration time.Duration
 	lastWrite      time.Time
+	stateLock      sync.RWMutex
+	// TODO(rjnagal): switch to atomic if writeFailures is the only protected data.
+	writeFailures int // guarded by stateLock
+}
+
+func (self *InfluxdbSink) recordWriteFailure() {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	self.writeFailures++
+}
+
+func (self *InfluxdbSink) getState() string {
+	self.stateLock.RLock()
+	defer self.stateLock.RUnlock()
+
+	return fmt.Sprintf("\tNumber of write failures: %d\n", self.writeFailures)
 }
 
 func (self *InfluxdbSink) containerStatsToValues(pod *sources.Pod, hostname, containerName string, spec cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) (columns []string, values []interface{}) {
@@ -171,6 +189,7 @@ func (self *InfluxdbSink) StoreData(ip Data) error {
 		err := self.client.WriteSeriesWithTimePrecision(seriesToFlush, influxdb.Second)
 		if err != nil {
 			glog.Errorf("failed to write stats to influxDb - %s", err)
+			self.recordWriteFailure()
 		}
 	}
 
@@ -181,6 +200,7 @@ func (self *InfluxdbSink) GetConfig() string {
 	desc := "Sink type: Influxdb\n"
 	desc += fmt.Sprintf("\tclient: Host %q, Database %q\n", *argDbHost, *argDbName)
 	desc += fmt.Sprintf("\tData buffering duration: %v\n", self.bufferDuration)
+	desc += self.getState()
 	desc += "\n"
 	return desc
 }


### PR DESCRIPTION
Sample output:
Heapster Version: 0.5

Source type: Kube
	Using kubelet port "10250"
	Supported kubelet versions [v0.3]
	Healthy Nodes:
		kubernetes-minion-1.c.vishnuk-cloud.internal
		kubernetes-minion-2.c.vishnuk-cloud.internal
	No node errors
	No pod errors

Sink type: Influxdb
	client: Host "10.0.113.151:8085", Database "k8s"
	Data buffering duration: 10s
	Number of write failures: 4