### PR TITLE
Support kube namespaces 

### DIFF
--- a/integration/.jenkins.sh
+++ b/integration/.jenkins.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -x
+SUPPORTED_KUBE_VERSIONS="0.9.0"
+
 export GOPATH="$JENKINS_HOME/workspace/project"
 export GOBIN="$GOPATH/bin"
 
@@ -7,5 +9,5 @@ deploy/build-test.sh \
 && influx-grafana/grafana/build-test.sh \
 && influx-grafana/influxdb/build-test.sh \
 && pushd integration \
-&& godep go test -a -v --vmodule=*=1 --timeout=30m github.com/GoogleCloudPlatform/heapster/integration/... \
+&& godep go test -a -v --vmodule=*=1 --timeout=30m --kube_versions=$SUPPORTED_KUBE_VERSIONS github.com/GoogleCloudPlatform/heapster/integration/... \
 && popd

--- a/integration/kube_test.go
+++ b/integration/kube_test.go
@@ -40,7 +40,7 @@ var (
 	heapsterFirewallRule        = "heapster-e2e"
 	influxdbLabels              = map[string]string{"name": "influxGrafana"}
 	heapsterLabels              = map[string]string{"name": "heapster"}
-	kubeVersions                = flag.String("kube_versions", "0.7.2,0.8.1", "Comma separated list of kube versions to test against")
+	kubeVersions                = flag.String("kube_versions", "", "Comma separated list of kube versions to test against")
 	heapsterManifestFile        = flag.String("heapster_controller", "../deploy/heapster-controller.yaml", "Path to heapster replication controller file.")
 	influxdbGrafanaManifestFile = flag.String("influxdb_grafana_controller", "../deploy/influxdb-grafana-controller.yaml", "Path to Influxdb-Grafana replication controller file.")
 	influxdbServiceFile         = flag.String("influxdb_service", "../deploy/influxdb-service.yaml", "Path to Inlufxdb service file.")

--- a/sources/kube.go
+++ b/sources/kube.go
@@ -52,11 +52,9 @@ type KubeSource struct {
 	lastQuery   time.Time
 	kubeletPort string
 	stateLock   sync.RWMutex
-	// Set of pod instances that have return data at least once.
-	activePods map[PodInstance]bool
-	goodNodes  []string            // guarded by stateLock
-	nodeErrors map[string]int      // guarded by stateLock
-	podErrors  map[PodInstance]int // guarded by stateLock
+	goodNodes   []string            // guarded by stateLock
+	nodeErrors  map[string]int      // guarded by stateLock
+	podErrors   map[PodInstance]int // guarded by stateLock
 }
 
 type nodeList CadvisorHosts
@@ -68,39 +66,17 @@ func (self *KubeSource) recordNodeError(name string) {
 	self.nodeErrors[name]++
 }
 
-func (self *KubeSource) addActivePodInstance(podName, podId, hostIp string) {
-	podInstance := PodInstance{Pod: podName, PodId: podId, HostIp: hostIp}
-	self.activePods[podInstance] = true
-}
-
-func (self *KubeSource) cleanupPods(pods []Pod) {
-	self.stateLock.Lock()
-	defer self.stateLock.Unlock()
-	newActivePods := make(map[PodInstance]bool)
-	newPodErrors := make(map[PodInstance]int)
-	for _, pod := range pods {
-		podInstance := PodInstance{Pod: pod.Name, PodId: pod.ID, HostIp: pod.HostIP}
-		if self.activePods[podInstance] {
-			newActivePods[podInstance] = true
-			if self.podErrors[podInstance] != 0 {
-				newPodErrors[podInstance] = self.podErrors[podInstance]
-			}
-		}
-	}
-	self.activePods = newActivePods
-	self.podErrors = newPodErrors
-}
-
-func (self *KubeSource) recordPodError(podName, podId, hostIp string) {
-	self.stateLock.Lock()
-	defer self.stateLock.Unlock()
-	podInstance := PodInstance{Pod: podName, PodId: podId, HostIp: hostIp}
-
+func (self *KubeSource) recordPodError(pod Pod) {
 	// Heapster knows about pods before they are up and running on a node.
-	// Ignore errors till we have seen an instance up at least once.
-	if !self.activePods[podInstance] {
+	// Ignore errors for Pods that are not Running.
+	if pod.Status != "Running" {
 		return
 	}
+
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	podInstance := PodInstance{Pod: pod.Name, PodId: pod.ID, HostIp: pod.HostIP}
 	self.podErrors[podInstance]++
 }
 
@@ -192,6 +168,7 @@ func (self *KubeSource) getPods() ([]Pod, error) {
 	// TODO(vishh): Add API Version check. Fail if Kubernetes returns an invalid API Version.
 	out := make([]Pod, 0)
 	for _, pod := range pods.Items {
+		glog.V(2).Infof("Got Kube Pod: %+v", pod)
 		pod := self.parsePod(&pod)
 		addrs, err := net.LookupIP(pod.Hostname)
 		if err != nil {
@@ -202,16 +179,15 @@ func (self *KubeSource) getPods() ([]Pod, error) {
 		pod.HostIP = addrs[0].String()
 		out = append(out, *pod)
 	}
-	self.cleanupPods(out)
 
 	return out, nil
 }
 
-func (self *KubeSource) getStatsFromKubelet(hostIP string, pod Pod, containerName string) (cadvisor.ContainerSpec, []*cadvisor.ContainerStats, error) {
+func (self *KubeSource) getStatsFromKubelet(pod Pod, containerName string) (cadvisor.ContainerSpec, []*cadvisor.ContainerStats, error) {
 	var containerInfo cadvisor.ContainerInfo
 	values := url.Values{}
 	values.Add("num_stats", strconv.Itoa(int(time.Since(self.lastQuery)/time.Second)))
-	url := "http://" + hostIP + ":" + self.kubeletPort + filepath.Join("/stats", pod.Namespace, pod.Name, pod.ID, containerName) + "?" + values.Encode()
+	url := "http://" + pod.HostIP + ":" + self.kubeletPort + filepath.Join("/stats", pod.Namespace, pod.Name, pod.ID, containerName) + "?" + values.Encode()
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return cadvisor.ContainerSpec{}, []*cadvisor.ContainerStats{}, err
@@ -219,10 +195,9 @@ func (self *KubeSource) getStatsFromKubelet(hostIP string, pod Pod, containerNam
 	err = PostRequestAndGetValue(&http.Client{}, req, &containerInfo)
 	if err != nil {
 		glog.Errorf("failed to get stats from kubelet url: %s - %s\n", url, err)
-		self.recordPodError(pod.Name, pod.ID, hostIP)
+		self.recordPodError(pod)
 		return cadvisor.ContainerSpec{}, []*cadvisor.ContainerStats{}, nil
 	}
-	self.addActivePodInstance(podName, podID, hostIP)
 
 	return containerInfo.Spec, containerInfo.Stats, nil
 }
@@ -234,7 +209,7 @@ func (self *KubeSource) getNodesInfo() ([]RawContainer, error) {
 	}
 	nodesInfo := []RawContainer{}
 	for node, ip := range kubeNodes.Hosts {
-		spec, stats, err := self.getStatsFromKubelet(ip, Pod{}, "/")
+		spec, stats, err := self.getStatsFromKubelet(Pod{HostIP: ip}, "/")
 		if err != nil {
 			glog.V(1).Infof("Failed to get machine stats from kubelet for node %s", node)
 			return []RawContainer{}, err
@@ -255,7 +230,7 @@ func (self *KubeSource) GetInfo() (ContainerData, error) {
 	}
 	for _, pod := range pods {
 		for _, container := range pod.Containers {
-			spec, stats, err := self.getStatsFromKubelet(hostIP, pod, container.Name)
+			spec, stats, err := self.getStatsFromKubelet(pod, container.Name)
 			if err != nil {
 				return ContainerData{}, err
 			}
@@ -292,7 +267,6 @@ func newKubeSource() (*KubeSource, error) {
 		client:      kubeClient,
 		lastQuery:   time.Now(),
 		kubeletPort: *argKubeletPort,
-		activePods:  make(map[PodInstance]bool),
 		nodeErrors:  make(map[string]int),
 		podErrors:   make(map[PodInstance]int),
 	}, nil

--- a/sources/types.go
+++ b/sources/types.go
@@ -37,6 +37,7 @@ func newContainer() *Container {
 // PodState is the state of a pod, used as either input (desired state) or output (current state)
 type Pod struct {
 	Name       string            `json:"name,omitempty"`
+	Namespace  string            `json:"namespace,omitempty"`
 	ID         string            `json:"id,omitempty"`
 	Hostname   string            `json:"hostname,omitempty"`
 	Containers []*Container      `json:"containers"`


### PR DESCRIPTION
Fixes #31.

This PR breaks backwards compatibility since the new kubelet API is available only from versions 0.9.0. Users who run older clusters can use an older version of heapster though.