### PR TITLE
Allow https kube master

### DIFF
--- a/sources/kube.go
+++ b/sources/kube.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -250,10 +251,15 @@ func newKubeSource() (*KubeSource, error) {
 	if len(*argMaster) == 0 {
 		return nil, fmt.Errorf("kubernetes_master flag not specified")
 	}
+
+	if !(strings.HasPrefix(*argMaster, "http://") || strings.HasPrefix(*argMaster, "https://")) {
+		*argMaster = "http://" + *argMaster
+	}
+
 	kubeClient := kube_client.NewOrDie(&kube_client.Config{
-		Host:     "http://" + *argMaster,
+		Host:     *argMaster,
 		Version:  kubeClientVersion,
-		Insecure: true,
+		Insecure: *argMasterInsecure,
 	})
 
 	glog.Infof("Using Kubernetes client with master %q and version %s\n", *argMaster, kubeClientVersion)

--- a/sources/types.go
+++ b/sources/types.go
@@ -16,12 +16,14 @@ package sources
 
 import (
 	"flag"
+
 	cadvisor "github.com/google/cadvisor/info"
 )
 
 var (
-	argMaster      = flag.String("kubernetes_master", "", "Kubernetes master IP")
-	argKubeletPort = flag.String("kubelet_port", "10250", "Kubelet port")
+	argMaster         = flag.String("kubernetes_master", "", "Kubernetes master address")
+	argMasterInsecure = flag.Bool("kubernetes_insecure", true, "Trust Kubernetes master certificate (if using https)")
+	argKubeletPort    = flag.String("kubelet_port", "10250", "Kubelet port")
 )
 
 type Container struct {


### PR DESCRIPTION
Currently this is hard coded as http. This PR lets user specify URL including protocol to use, defaulting to http so as not to affect existing users.