### PR TITLE
Add in support for Kubernetes API service port

### DIFF
--- a/deploy/influxdb-grafana-controller.yaml
+++ b/deploy/influxdb-grafana-controller.yaml
@@ -32,8 +32,10 @@ desiredState:
               - name: "INFLUXDB_PROTO"
                 value: "https"
               - name: "INFLUXDB_HOST"
-                value: '"+window.location.hostname+"/api/v1beta1/proxy/services/monitoring-influxdb'
+                value: "localhost"
               - name: "INFLUXDB_PORT"
+                value: ""
+              - name: "KUBERNETES_API_PORT"
                 value: ""
 labels:
   name: "influxGrafana"

--- a/influx-grafana/grafana/set_influx_db.sh
+++ b/influx-grafana/grafana/set_influx_db.sh
@@ -21,11 +21,12 @@ if [ "${INFLUXDB_PORT}" = "**ChangeMe**" ]; then
 fi
 
 url="${INFLUXDB_PROTO}://$INFLUXDB_HOST"
-if [ -z "${INFLUXDB_PORT}" ]; then
-  url="$url/db"
+if [ -z "${KUBERNETES_API_PORT}" ]; then
+  url="$url/api/v1beta1/proxy/services/monitoring-influxdb/db"
 else
-  url="$url:$INFLUXDB_PORT/db"
+  url="$url:$KUBERNETES_API_PORT/api/v1beta1/proxy/services/monitoring-influxdb/db"
 fi
+
 escaped_url=${url////\\/}
 
 echo "=> Configuring InfluxDB"


### PR DESCRIPTION
Since the new version of Heapster came out I've been troubleshooting an issue with Grafana in my bare metal Kubernetes cluster.  In the previous version, I was accessing the Grafana frontend directly from the pod IP address.  Since the access method changed to using the Kubernetes API server to access Grafana through the monitoring-grafana service the back end DB queries werent working.  The Grafana graphs were just spinning.  Looking at the web queries I saw that the issue was with API server trying to pull the data through the monitoring-influxdb service.  The issue is that by default the Kubernetes API service runs on port 8443 and the calls to the monitoring-influxdb service weren't specifying a port.  

I suggest the following changes....
-Add another ENV variable to the pod description to specify the API server port (8443 in my case but maybe that's different in GCE?)
-Change the port logic in set_influx_db.sh to use the new ENV variable for the API server port and append the URI required to access the service through the API to the URL string.  This also means that the ENV variable INFLUXDB_HOST will only specify the host, not the full API path.

Im not sure if the INFLUXDB_PORT is relevant in this script since we're accessing it through the API and service so I just reused the logic that evaluated the INFLUXDB_PORT for the KUBERNETES_API_PORT.  

I'll point out that Im a GitHub newb here so if Im not filing this correctly just let me know where I went wrong.  