### PR TITLE
Fix exit code issue in jenkins integration test script.

### DIFF
--- a/integration/.jenkins.sh
+++ b/integration/.jenkins.sh
@@ -11,9 +11,10 @@ TEST_NAMESPACE="default"
 export GOPATH="$JENKINS_HOME/workspace/project"
 export GOBIN="$GOPATH/bin"
 
-deploy/build-test.sh \
-&& influx-grafana/grafana/build-test.sh \
-&& influx-grafana/influxdb/build-test.sh \
-&& cd integration \
-&& godep go test -a -v --vmodule=*=1 --timeout=30m --namespace=$TEST_NAMESPACE --kube_versions=$SUPPORTED_KUBE_VERSIONS github.com/GoogleCloudPlatform/heapster/integration/...;
+result=$(deploy/build-test.sh \
+  && influx-grafana/grafana/build-test.sh \
+  && influx-grafana/influxdb/build-test.sh \
+  && cd integration \
+  && godep go test -a -v --vmodule=*=1 --timeout=30m --namespace=$TEST_NAMESPACE --kube_versions=$SUPPORTED_KUBE_VERSIONS github.com/GoogleCloudPlatform/heapster/integration/...)
 docker rmi -f `docker images -q` || true
+exit $result


### PR DESCRIPTION
Its time to do all this in golang and not get bitten by bash in the future. 