### PR TITLE
Use GCM sink if SINK=gcm is specified.

### DIFF
--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -12,22 +12,42 @@ if [ ! -x $CADVISOR_PORT ]; then
   EXTRA_ARGS="$EXTRA_ARGS --cadvisor_port=$CADVISOR_PORT"
 fi
 
-HEAPSTER="/usr/bin/heapster $EXTRA_ARGS "
-# Check if InfluxDB service is running
+# If in Kubernetes, target the master.
 if [ ! -z $KUBERNETES_RO_SERVICE_HOST ]; then
-  # TODO(vishh): add support for passing in user name and password.    
-  INFLUXDB_ADDRESS=""
-  if [ ! -z $MONITORING_INFLUXDB_SERVICE_HOST ]; then
-    INFLUXDB_ADDRESS="${MONITORING_INFLUXDB_SERVICE_HOST}:${MONITORING_INFLUXDB_SERVICE_PORT}"
+  EXTRA_ARGS="$EXTRA_ARGS --kubernetes_master ${KUBERNETES_RO_SERVICE_HOST}:${KUBERNETES_RO_SERVICE_PORT}"
+fi
+
+# Select what source sink to use. Options: "influxdb,gcm"
+# Default is InfluxDB.
+if [ -x $SINK ]; then
+  SINK="influxdb"
+fi
+
+HEAPSTER="/usr/bin/heapster $EXTRA_ARGS "
+
+if [ "$SINK" == "influxdb" ]; then
+  HEAPSTER="$HEAPSTER --sink influxdb"
+
+  # Check if in Kubernetes.
+  if [ ! -z $KUBERNETES_RO_SERVICE_HOST ]; then
+    # TODO(vishh): add support for passing in user name and password.
+    INFLUXDB_ADDRESS=""
+    if [ ! -z $MONITORING_INFLUXDB_SERVICE_HOST ]; then
+      INFLUXDB_ADDRESS="${MONITORING_INFLUXDB_SERVICE_HOST}:${MONITORING_INFLUXDB_SERVICE_PORT}"
+    elif [ ! -z $INFLUXDB_HOST ]; then
+      INFLUXDB_ADDRESS=${INFLUXDB_HOST}
+    else
+      echo "InfluxDB service address not specified. Exiting."
+      exit 1
+    fi
+    $HEAPSTER --sink_influxdb_host $INFLUXDB_ADDRESS
   elif [ ! -z $INFLUXDB_HOST ]; then
-    INFLUXDB_ADDRESS=${INFLUXDB_HOST}
-  else 
-    echo "InfluxDB service address not found. Exiting."
-    exit 1
+    $HEAPSTER --sink_influxdb_host ${INFLUXDB_HOST}
+  else
+    $HEAPSTER
   fi
-  $HEAPSTER --kubernetes_master "${KUBERNETES_RO_SERVICE_HOST}:${KUBERNETES_RO_SERVICE_PORT}" --sink influxdb --sink_influxdb_host $INFLUXDB_ADDRESS
-elif [ ! -z $INFLUXDB_HOST ]; then
-  $HEAPSTER --sink influxdb --sink_influxdb_host ${INFLUXDB_HOST}
+elif [ "$SINK" == "gcm" ]; then
+  $HEAPSTER --sink gcm
 else
   $HEAPSTER
 fi


### PR DESCRIPTION
Default is influxdb which mirrors today's behavior.

Fixes #117.