### PR TITLE
Support standalone mode throught the --standalone flag.

### DIFF
--- a/sources/nodes/external_test.go
+++ b/sources/nodes/external_test.go
@@ -72,7 +72,7 @@ func TestExternalFile(t *testing.T) {
 }
 
 func TestLocalhostMonitoring(t *testing.T) {
-	*hostsFile = ""
+	*standaloneMode = true
 	nodesApi, err := NewExternalNodes()
 	require.NoError(t, err)
 


### PR DESCRIPTION
Replaces the old method of specifying an empty external hosts file to an
explicit --standalone flag.