### PR TITLE
Adding Influxdb sequence number generator

### DIFF
--- a/sinks/influxdb/sequence_number.go
+++ b/sinks/influxdb/sequence_number.go
@@ -1,0 +1,40 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package influxdb
+
+import (
+	"sync"
+)
+
+type metricSequenceNum interface {
+	Get(metric string) uint64
+}
+
+type realMetricSequenceNum struct {
+	store map[string]uint64
+	lock sync.Mutex
+}
+
+func (self *realMetricSequenceNum) Get(metric string) uint64 {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	ret := self.store[metric]
+	self.store[metric]++
+	return ret
+}
+
+func newMetricSequenceNum() metricSequenceNum {
+	return &realMetricSequenceNum{store: make(map[string]uint64)}
+}

--- a/sinks/influxdb/sequence_number_test.go
+++ b/sinks/influxdb/sequence_number_test.go
@@ -1,0 +1,30 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package influxdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSequenceNumberGeneration(t *testing.T) {
+	generator := newMetricSequenceNum()
+	require.Equal(t, generator.Get("A"), 0)
+	require.Equal(t, generator.Get("A"), 1)
+	require.Equal(t, generator.Get("B"), 0)
+	require.Equal(t, generator.Get("B"), 1)
+	require.Equal(t, generator.Get("A"), 2)
+}


### PR DESCRIPTION
This is required for proper ordering of cpu cumulative stats. Without this computing instantaneous cpu usage seems to be error prone.