### PR TITLE
deploy: update INFLUXDB_HOST including the port

### DIFF
--- a/deploy/kube-config/v1beta3/influxdb-grafana-controller.yaml
+++ b/deploy/kube-config/v1beta3/influxdb-grafana-controller.yaml
@@ -33,9 +33,9 @@ spec:
             - name: "HTTP_PASS"
               value: "**None**"
             - name: "INFLUXDB_PROTO"
-              value: "https"
+              value: '"+window.location.protocol.slice(0,-1)+"'
             - name: "INFLUXDB_HOST"
-              value: '"+window.location.hostname+"/api/v1beta1/proxy/services/monitoring-influxdb'
+              value: '"+window.location.host+"'
             - name: "INFLUXDB_PORT"
               value: ""
             - name: "KUBERNETES_API_PORT"


### PR DESCRIPTION
This patch adds the port to the influxdb host and removes the url path (/api/v1beta1/proxy/...) that is already included inside the run.sh script of heapster_grafana:v0.5.
