### PR TITLE
Add back in command line insecure flag client config

### DIFF
--- a/sources/kube.go
+++ b/sources/kube.go
@@ -215,8 +215,9 @@ func newKubeSource(pollDuration time.Duration) (*kubeSource, error) {
 	}
 
 	kubeConfig := kube_client.Config{
-		Host:    *argMaster,
-		Version: kubeClientVersion,
+		Host:     *argMaster,
+		Version:  kubeClientVersion,
+		Insecure: *argMasterInsecure,
 	}
 
 	if len(*argClientAuthFile) > 0 {


### PR DESCRIPTION
Missed when I added the kube clientauth piece - useful to be able to override insecure flag with command flag.