### PR TITLE
Push events to influxdb heapster sink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 heapster
+
+# Vim-related files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist

--- a/sinks/api/eventdecoder.go
+++ b/sinks/api/eventdecoder.go
@@ -1,0 +1,85 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+
+	source_api "github.com/GoogleCloudPlatform/heapster/sources/api"
+	kube_api "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+const (
+	EventsSeriesName = "log/events"
+)
+
+type eventDecoder struct{}
+
+func NewEventDecoder() Decoder {
+	return &eventDecoder{}
+}
+
+func (self *eventDecoder) Timeseries(data source_api.AggregateData) ([]Timeseries, error) {
+	result := []Timeseries{}
+	if data.Events != nil && len(data.Events) > 0 {
+		points := []Point{}
+		for _, event := range data.Events {
+			value, err := getEventValue(&event)
+			if err != nil {
+				return result, err
+			}
+			points = append(points, Point{
+				Labels: getEventLabels(&event),
+				Start:  event.LastTimestamp.Time,
+				End:    event.LastTimestamp.Time,
+				Value:  value,
+			})
+		}
+		result = append(result, Timeseries{
+			SeriesName:    EventsSeriesName,
+			TimePrecision: Millisecond,
+			LabelKeys:     SupportedLabelKeys(),
+			Points:        points,
+		})
+	}
+
+	return result, nil
+
+}
+
+// Generate the labels.
+func getEventLabels(event *kube_api.Event) map[string]string {
+	labels := make(map[string]string)
+	if event == nil {
+		return nil
+	}
+
+	labels[labelHostname] = event.Source.Host
+	if event.InvolvedObject.Kind == "Pod" {
+		labels[labelPodName] = event.InvolvedObject.Name
+		labels[labelPodId] = string(event.InvolvedObject.UID)
+	}
+
+	return labels
+}
+
+// Generate point value for event
+func getEventValue(event *kube_api.Event) (string, error) {
+	bytes, err := json.MarshalIndent(event, "", " ")
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}

--- a/sinks/api/eventdecoder_test.go
+++ b/sinks/api/eventdecoder_test.go
@@ -1,0 +1,127 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	source_api "github.com/GoogleCloudPlatform/heapster/sources/api"
+	kube_api "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kube_time "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventDecoderEmptyInput(t *testing.T) {
+	// Arrange
+	events := []kube_api.Event{}
+	input := source_api.AggregateData{
+		Events: events,
+	}
+
+	// Act
+	timeseries, err := NewEventDecoder().Timeseries(input)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Empty(t, timeseries)
+}
+
+func TestEventDecoderSingleEvent(t *testing.T) {
+	// Arrange
+	eventTime := kube_time.Unix(12345, 0)
+	eventSourceHostname := "event1HostName"
+	events := []kube_api.Event{
+		kube_api.Event{
+			Reason:        "event1",
+			LastTimestamp: eventTime,
+			Source: kube_api.EventSource{
+				Host: eventSourceHostname,
+			},
+		},
+	}
+	input := source_api.AggregateData{
+		Events: events,
+	}
+
+	// Act
+	timeseries, err := NewEventDecoder().Timeseries(input)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotEmpty(t, timeseries)
+	assert.Equal(t, 1, len(timeseries))
+	assert.Equal(t, EventsSeriesName, timeseries[0].SeriesName)
+	assert.Equal(t, Millisecond, timeseries[0].TimePrecision)
+	assert.Equal(t, SupportedLabelKeys(), timeseries[0].LabelKeys)
+	assert.Equal(t, 1, len(timeseries[0].Points))
+	assert.Equal(t, eventTime.Time, timeseries[0].Points[0].Start)
+	assert.Equal(t, eventTime.Time, timeseries[0].Points[0].End)
+	assert.Equal(t, 1, len(timeseries[0].Points[0].Labels))
+	assert.Equal(t, eventSourceHostname, timeseries[0].Points[0].Labels[labelHostname])
+	expectedValue := "{\n \"metadata\": {\n  \"creationTimestamp\": null\n },\n \"involvedObject\": {},\n \"reason\": \"event1\",\n \"source\": {\n  \"host\": \"event1HostName\"\n },\n \"firstTimestamp\": null,\n \"lastTimestamp\": \"1970-01-01T03:25:45Z\"\n}"
+	assert.Equal(t, expectedValue, timeseries[0].Points[0].Value)
+}
+
+func TestEventDecoderMultipleEvents(t *testing.T) {
+	// Arrange
+	event1Time := kube_time.Unix(12345, 0)
+	event2Time := kube_time.Unix(54321, 0)
+	event1SourceHostname := "event1HostName"
+	event2SourceHostname := "event2HostName"
+	events := []kube_api.Event{
+		kube_api.Event{
+			Reason:        "event1",
+			LastTimestamp: event1Time,
+			Source: kube_api.EventSource{
+				Host: event1SourceHostname,
+			},
+		},
+		kube_api.Event{
+			Reason:        "event2",
+			LastTimestamp: event2Time,
+			Source: kube_api.EventSource{
+				Host: event2SourceHostname,
+			},
+		},
+	}
+	input := source_api.AggregateData{
+		Events: events,
+	}
+
+	// Act
+	timeseries, err := NewEventDecoder().Timeseries(input)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotEmpty(t, timeseries)
+	assert.Equal(t, 1, len(timeseries))
+	assert.Equal(t, EventsSeriesName, timeseries[0].SeriesName)
+	assert.Equal(t, Millisecond, timeseries[0].TimePrecision)
+	assert.Equal(t, SupportedLabelKeys(), timeseries[0].LabelKeys)
+	assert.Equal(t, 2, len(timeseries[0].Points))
+	assert.Equal(t, event1Time.Time, timeseries[0].Points[0].Start)
+	assert.Equal(t, event1Time.Time, timeseries[0].Points[0].End)
+	assert.Equal(t, 1, len(timeseries[0].Points[0].Labels))
+	assert.Equal(t, event1SourceHostname, timeseries[0].Points[0].Labels[labelHostname])
+	expectedValue := "{\n \"metadata\": {\n  \"creationTimestamp\": null\n },\n \"involvedObject\": {},\n \"reason\": \"event1\",\n \"source\": {\n  \"host\": \"event1HostName\"\n },\n \"firstTimestamp\": null,\n \"lastTimestamp\": \"1970-01-01T03:25:45Z\"\n}"
+	assert.Equal(t, expectedValue, timeseries[0].Points[0].Value)
+	assert.Equal(t, event2Time.Time, timeseries[0].Points[1].Start)
+	assert.Equal(t, event2Time.Time, timeseries[0].Points[1].End)
+	assert.Equal(t, 1, len(timeseries[0].Points[1].Labels))
+	assert.Equal(t, event2SourceHostname, timeseries[0].Points[1].Labels[labelHostname])
+	expectedValue = "{\n \"metadata\": {\n  \"creationTimestamp\": null\n },\n \"involvedObject\": {},\n \"reason\": \"event2\",\n \"source\": {\n  \"host\": \"event2HostName\"\n },\n \"firstTimestamp\": null,\n \"lastTimestamp\": \"1970-01-01T15:05:21Z\"\n}"
+	assert.Equal(t, expectedValue, timeseries[0].Points[1].Value)
+
+}

--- a/sinks/api/supported_labels.go
+++ b/sinks/api/supported_labels.go
@@ -16,6 +16,7 @@ package api
 
 const (
 	labelPodId         = "pod_id"
+	labelPodName       = "pod_name"
 	labelContainerName = "container_name"
 	labelLabels        = "labels"
 	labelHostname      = "hostname"
@@ -29,6 +30,10 @@ var allLabels = []LabelDescriptor{
 	{
 		Key:         labelPodId,
 		Description: "The unique ID of the pod",
+	},
+	{
+		Key:         labelPodName,
+		Description: "The name of the pod",
 	},
 	{
 		Key:         labelContainerName,
@@ -50,4 +55,12 @@ var allLabels = []LabelDescriptor{
 
 func SupportedLabels() []LabelDescriptor {
 	return allLabels
+}
+
+func SupportedLabelKeys() []string {
+	keys := []string{}
+	for _, label := range allLabels {
+		keys = append(keys, label.Key)
+	}
+	return keys
 }

--- a/sinks/api/types.go
+++ b/sinks/api/types.go
@@ -172,14 +172,16 @@ type Timeseries struct {
 type ExternalSink interface {
 	// Registers a metric with the backend.
 	Register([]MetricDescriptor) error
-	// Stores input data into the backend.
-	// Support input types are as follows:
-	// 1. []Timeseries
-	// TODO: Add map[string]string to support storing raw data like node or pod status, spec, etc.
-	// TODO: Add events.
-	StoreTimeseries([]Timeseries) error
+	// Stores input data into the backend. This is an array of Timeseries array pointers so
+	// that Timeseries arrays from multiple decoders can be combined with append without being
+	// copied.
+	StoreTimeseries([]*[]Timeseries) error
 	// Returns debug information specific to the sink.
 	DebugInfo() string
+	// Returns true if this sink supports metrics
+	SupportsMetrics() bool
+	// Returns true if this sink supports events
+	SupportsEvents() bool
 }
 
 // Codec represents an engine that translated from sources.api to sink.api objects.

--- a/sinks/api/types.go
+++ b/sinks/api/types.go
@@ -89,6 +89,14 @@ func (self *MetricUnitsType) String() string {
 	return ""
 }
 
+type TimePrecision string
+
+const (
+	Second      TimePrecision = "s"
+	Millisecond TimePrecision = "m"
+	Microsecond TimePrecision = "u"
+)
+
 type LabelDescriptor struct {
 	// Key to use for the label.
 	Key string `json:"key,omitempty"`
@@ -115,17 +123,14 @@ type MetricDescriptor struct {
 }
 
 type Point struct {
-	// The name of the metric. Must match an existing descriptor.
-	Name string
-
-	// The labels and values for the metric. The keys must match those in the descriptor.
+	// The label keys and values for the metric.
 	Labels map[string]string
 
-	// The start and end time for which this data is representative.
+	// The start and end time for which this data is representative and the precision of the timestamps.
 	Start time.Time
 	End   time.Time
 
-	// The value of the metric. Must match the type in the descriptor.
+	// The value of the metric.
 	Value interface{}
 }
 
@@ -148,10 +153,19 @@ type SupportedStatMetric struct {
 	GetValue func(*cadvisor.ContainerSpec, *cadvisor.ContainerStats) []internalPoint
 }
 
-// Timeseries represents a single metric.
+// Timeseries represents a set of points for a series.
 type Timeseries struct {
-	Point            *Point
-	MetricDescriptor *MetricDescriptor
+	// The name of the series.
+	SeriesName string
+
+	// Precision of points timestamps.
+	TimePrecision TimePrecision
+
+	// The labels used by this series.
+	LabelKeys []string
+
+	// The points to add to this series.
+	Points []Point
 }
 
 // ExternalSink is the interface that needs to be implemented by all external storage backends.

--- a/sinks/gcm/driver.go
+++ b/sinks/gcm/driver.go
@@ -141,43 +141,44 @@ type metricWriteRequest struct {
 const maxTimeseriesPerRequest = 200
 
 // Pushes the specified metric values in input. The metrics must already exist.
-func (self *gcmSink) StoreTimeseries(input []sink_api.Timeseries) error {
+func (self *gcmSink) StoreTimeseries(inputTimeseriesList []sink_api.Timeseries) error {
 	// Ensure the metrics exist.
-	for _, entry := range input {
-		metric := entry.Point
+	for _, inputTimeseries := range inputTimeseriesList {
 		// TODO: Remove this check if possible.
-		if _, ok := self.exportedMetrics[metric.Name]; !ok {
-			return fmt.Errorf("unable to push unknown metric %q", metric.Name)
+		if _, ok := self.exportedMetrics[inputTimeseries.SeriesName]; !ok {
+			return fmt.Errorf("unable to push unknown metric %q", inputTimeseries.SeriesName)
 		}
 	}
 
 	// Build a map of metrics by name.
 	metrics := make(map[string][]timeseries)
-	for _, entry := range input {
-		metric := entry.Point
+	for _, inputTimeseries := range inputTimeseriesList {
+		// Ideally we should put multiple points in a single timeseries, but since GCM requires all points in a time series
+		// to share a single set of labels, we can't do this.
+		for _, inputPoint := range inputTimeseries.Points {
+			// Use full label names.
+			labels := make(map[string]string, len(inputPoint.Labels))
+			for key, value := range inputPoint.Labels {
+				labels[fullLabelName(key)] = value
+			}
 
-		// Use full label names.
-		labels := make(map[string]string, len(metric.Labels))
-		for key, value := range metric.Labels {
-			labels[fullLabelName(key)] = value
+			// TODO(vmarmol): Validation and cleanup of data.
+			// TODO(vmarmol): Handle non-int64 data types. There is an issue with using omitempty since 0 is a valid value for us.
+			if _, ok := inputPoint.Value.(int64); !ok {
+				return fmt.Errorf("non-int64 data not implemented. Seen for metric %q", inputTimeseries.SeriesName)
+			}
+			metrics[inputTimeseries.SeriesName] = append(metrics[inputTimeseries.SeriesName], timeseries{
+				TimeseriesDescriptor: timeseriesDescriptor{
+					Metric: fullMetricName(inputTimeseries.SeriesName),
+					Labels: labels,
+				},
+				Point: point{
+					Start:      inputPoint.Start,
+					End:        inputPoint.End,
+					Int64Value: inputPoint.Value.(int64),
+				},
+			})
 		}
-
-		// TODO(vmarmol): Validation and cleanup of data.
-		// TODO(vmarmol): Handle non-int64 data types. There is an issue with using omitempty since 0 is a valid value for us.
-		if _, ok := metric.Value.(int64); !ok {
-			return fmt.Errorf("non-int64 data not implemented. Seen for metric %q", metric.Name)
-		}
-		metrics[metric.Name] = append(metrics[metric.Name], timeseries{
-			TimeseriesDescriptor: timeseriesDescriptor{
-				Metric: fullMetricName(metric.Name),
-				Labels: labels,
-			},
-			Point: point{
-				Start:      metric.Start,
-				End:        metric.End,
-				Int64Value: metric.Value.(int64),
-			},
-		})
 	}
 
 	// Only send one metric of each type per request.

--- a/sinks/gcm/driver.go
+++ b/sinks/gcm/driver.go
@@ -115,6 +115,16 @@ func (self *gcmSink) Register(metrics []sink_api.MetricDescriptor) error {
 	return nil
 }
 
+// Returns true if this sink supports metrics
+func (sink *gcmSink) SupportsMetrics() bool {
+	return true
+}
+
+// Returns true if this sink supports events
+func (sink *gcmSink) SupportsEvents() bool {
+	return false
+}
+
 // GCM request structures for writing time-series data.
 type timeseriesDescriptor struct {
 	Project string            `json:"project,omitempty"`
@@ -141,43 +151,51 @@ type metricWriteRequest struct {
 const maxTimeseriesPerRequest = 200
 
 // Pushes the specified metric values in input. The metrics must already exist.
-func (self *gcmSink) StoreTimeseries(inputTimeseriesList []sink_api.Timeseries) error {
+func (self *gcmSink) StoreTimeseries(inputTimeseriesLists []*[]sink_api.Timeseries) error {
 	// Ensure the metrics exist.
-	for _, inputTimeseries := range inputTimeseriesList {
-		// TODO: Remove this check if possible.
-		if _, ok := self.exportedMetrics[inputTimeseries.SeriesName]; !ok {
-			return fmt.Errorf("unable to push unknown metric %q", inputTimeseries.SeriesName)
+	for _, inputTimeseriesList := range inputTimeseriesLists {
+		if inputTimeseriesList != nil {
+			for _, inputTimeseries := range *inputTimeseriesList {
+				// TODO: Remove this check if possible.
+				if _, ok := self.exportedMetrics[inputTimeseries.SeriesName]; !ok {
+					return fmt.Errorf("unable to push unknown metric %q", inputTimeseries.SeriesName)
+				}
+			}
 		}
 	}
 
 	// Build a map of metrics by name.
 	metrics := make(map[string][]timeseries)
-	for _, inputTimeseries := range inputTimeseriesList {
-		// Ideally we should put multiple points in a single timeseries, but since GCM requires all points in a time series
-		// to share a single set of labels, we can't do this.
-		for _, inputPoint := range inputTimeseries.Points {
-			// Use full label names.
-			labels := make(map[string]string, len(inputPoint.Labels))
-			for key, value := range inputPoint.Labels {
-				labels[fullLabelName(key)] = value
-			}
+	for _, inputTimeseriesList := range inputTimeseriesLists {
+		if inputTimeseriesList != nil {
+			for _, inputTimeseries := range *inputTimeseriesList {
+				// Ideally we should put multiple points in a single timeseries, but since GCM requires all points in a time series
+				// to share a single set of labels, we can't do this.
+				for _, inputPoint := range inputTimeseries.Points {
+					// Use full label names.
+					labels := make(map[string]string, len(inputPoint.Labels))
+					for key, value := range inputPoint.Labels {
+						labels[fullLabelName(key)] = value
+					}
 
-			// TODO(vmarmol): Validation and cleanup of data.
-			// TODO(vmarmol): Handle non-int64 data types. There is an issue with using omitempty since 0 is a valid value for us.
-			if _, ok := inputPoint.Value.(int64); !ok {
-				return fmt.Errorf("non-int64 data not implemented. Seen for metric %q", inputTimeseries.SeriesName)
+					// TODO(vmarmol): Validation and cleanup of data.
+					// TODO(vmarmol): Handle non-int64 data types. There is an issue with using omitempty since 0 is a valid value for us.
+					if _, ok := inputPoint.Value.(int64); !ok {
+						return fmt.Errorf("non-int64 data not implemented. Seen for metric %q", inputTimeseries.SeriesName)
+					}
+					metrics[inputTimeseries.SeriesName] = append(metrics[inputTimeseries.SeriesName], timeseries{
+						TimeseriesDescriptor: timeseriesDescriptor{
+							Metric: fullMetricName(inputTimeseries.SeriesName),
+							Labels: labels,
+						},
+						Point: point{
+							Start:      inputPoint.Start,
+							End:        inputPoint.End,
+							Int64Value: inputPoint.Value.(int64),
+						},
+					})
+				}
 			}
-			metrics[inputTimeseries.SeriesName] = append(metrics[inputTimeseries.SeriesName], timeseries{
-				TimeseriesDescriptor: timeseriesDescriptor{
-					Metric: fullMetricName(inputTimeseries.SeriesName),
-					Labels: labels,
-				},
-				Point: point{
-					Start:      inputPoint.Start,
-					End:        inputPoint.End,
-					Int64Value: inputPoint.Value.(int64),
-				},
-			})
 		}
 	}
 

--- a/sinks/influxdb/driver.go
+++ b/sinks/influxdb/driver.go
@@ -37,72 +37,116 @@ type influxdbSink struct {
 	seqNum        metricSequenceNum
 }
 
-func (self *influxdbSink) Register(metrics []sink_api.MetricDescriptor) error {
+func (sink *influxdbSink) Register(metrics []sink_api.MetricDescriptor) error {
 	// Create tags once influxDB v0.9.0 is released.
 	return nil
 }
 
-func (self *influxdbSink) metricToSeries(timeseries *sink_api.Timeseries) *influxdb.Series {
-	columns := []string{}
-	values := []interface{}{}
-	// TODO: move labels to tags once v0.9.0 is released.
-	seriesName := timeseries.Point.Name
-	if timeseries.MetricDescriptor.Units.String() != "" {
-		seriesName = fmt.Sprintf("%s_%s", seriesName, timeseries.MetricDescriptor.Units.String())
-	}
-	if timeseries.MetricDescriptor.Type.String() != "" {
-		seriesName = fmt.Sprintf("%s_%s", seriesName, timeseries.MetricDescriptor.Type.String())
-	}
-
-	// Add the real metric value.
-	columns = append(columns, "value")
-	values = append(values, timeseries.Point.Value)
-	// Append labels.
-	if !self.avoidColumns {
-		for key, value := range timeseries.Point.Labels {
-			columns = append(columns, key)
-			values = append(values, value)
+func (sink *influxdbSink) StoreTimeseries(timeseriesList []sink_api.Timeseries) error {
+	precisions := []sink_api.TimePrecision{sink_api.Second, sink_api.Millisecond, sink_api.Microsecond}
+	for _, precision := range precisions {
+		err := sink.storeTimeseriesWithPrecision(timeseriesList, precision)
+		if err != nil {
+			return err
 		}
-	} else {
-		seriesName = strings.Replace(seriesName, "/", "_", -1)
-		seriesName = fmt.Sprintf("%s_%s", sink_api.LabelsToString(timeseries.Point.Labels, "_"), seriesName)
 	}
-	// Add timestamp.
-	columns = append(columns, "time")
-	values = append(values, timeseries.Point.End.Unix())
-	// Ass sequence number
-	columns = append(columns, "sequence_number")
-	values = append(values, self.seqNum.Get(seriesName))
-
-	return self.newSeries(seriesName, columns, values)
+	return nil
 }
 
-func (self *influxdbSink) StoreTimeseries(timeseries []sink_api.Timeseries) error {
+func (sink *influxdbSink) storeTimeseriesWithPrecision(timeseriesList []sink_api.Timeseries, precision sink_api.TimePrecision) error {
 	dataPoints := []*influxdb.Series{}
-	for index := range timeseries {
-		dataPoints = append(dataPoints, self.metricToSeries(&timeseries[index]))
+	for _, timeseries := range timeseriesList {
+		if timeseries.TimePrecision == precision {
+			if !sink.avoidColumns {
+				dataPoints = append(dataPoints, sink.timeSeriesToInfluxdbSeries(&timeseries))
+			} else {
+				for _, point := range timeseries.Points {
+					dataPoints = append(dataPoints, sink.pointToInfluxdbSeriesNoColumn(timeseries.SeriesName, point))
+				}
+			}
+		}
 	}
+
 	// TODO: Group all datapoints belonging to a metric into a single series.
 	// TODO: Record the average time taken to flush data.
-	err := self.client.WriteSeriesWithTimePrecision(dataPoints, influxdb.Second)
-	if err != nil {
-		glog.Errorf("failed to write stats to influxDB - %s", err)
-		self.recordWriteFailure()
+	if len(dataPoints) > 0 {
+		err := sink.client.WriteSeriesWithTimePrecision(dataPoints, getInfluxdbPrecision(precision))
+		if err != nil {
+			glog.Errorf("failed to write time series to influxDB - %s", err)
+			for _, dataPoint := range dataPoints {
+				glog.Errorf("  detail: failed to write time series (%s) to influxDB with columns (%s)", dataPoint.Name, dataPoint.Columns)
+			}
+			sink.recordWriteFailure()
+			return err
+		}
+		glog.V(1).Info("Succesfully wrote %q timeseries to influxDB", precision)
 	}
-	glog.V(1).Info("flushed stats to influxDB")
-	return err
+	return nil
 }
 
-// Returns a new influxdb series.
-func (self *influxdbSink) newSeries(seriesName string, columns []string, points []interface{}) *influxdb.Series {
-	out := &influxdb.Series{
+func getInfluxdbPrecision(precision sink_api.TimePrecision) influxdb.TimePrecision {
+	switch precision {
+	case sink_api.Second:
+		return influxdb.Second
+	case sink_api.Millisecond:
+		return influxdb.Millisecond
+	case sink_api.Microsecond:
+		return influxdb.Microsecond
+	}
+	return influxdb.Second
+}
+
+func (sink *influxdbSink) timeSeriesToInfluxdbSeries(timeseries *sink_api.Timeseries) *influxdb.Series {
+	seriesName := timeseries.SeriesName
+
+	columns := []string{}
+	columns = append(columns, "time")            // Column 0 header
+	columns = append(columns, "value")           // Column 1 header
+	columns = append(columns, "sequence_number") // Column 2 header
+	for _, extraColumnName := range timeseries.LabelKeys {
+		columns = append(columns, extraColumnName) // Column 3+ header
+	}
+
+	points := make([][]interface{}, len(timeseries.Points))
+	for i, point := range timeseries.Points {
+		points[i] = make([]interface{}, len(columns))
+		points[i][0] = point.End.Unix()            // Column 0 Value
+		points[i][1] = point.Value                 // Column 1 Value
+		points[i][2] = sink.seqNum.Get(seriesName) // Column 2 Value
+		for j := 0; j < len(timeseries.LabelKeys); j++ {
+			points[i][j+3] = point.Labels[timeseries.LabelKeys[j]] // Column 3+ value
+		}
+	}
+
+	return &influxdb.Series{
 		Name:    seriesName,
 		Columns: columns,
-		// There's only one point for each stats
-		Points: make([][]interface{}, 1),
+		Points:  points,
 	}
-	out.Points[0] = points
-	return out
+}
+
+func (sink *influxdbSink) pointToInfluxdbSeriesNoColumn(seriesName string, point sink_api.Point) *influxdb.Series {
+	// Append labels to seriesName instead of adding extra columns
+	seriesName = strings.Replace(seriesName, "/", "_", -1)
+	seriesName = fmt.Sprintf("%s_%s", sink_api.LabelsToString(point.Labels, "_"), seriesName)
+
+	columns := []string{}
+	columns = append(columns, "time")            // Column 0 header
+	columns = append(columns, "value")           // Column 1 header
+	columns = append(columns, "sequence_number") // Column 2 header
+
+	// There's only one point per series for no columns
+	points := make([][]interface{}, 1)
+	points[0] = make([]interface{}, len(columns))
+	points[0][0] = point.End.Unix()            // Column 0 Value
+	points[0][1] = point.Value                 // Column 1 Value
+	points[0][2] = sink.seqNum.Get(seriesName) // Column 2 Value
+
+	return &influxdb.Series{
+		Name:    seriesName,
+		Columns: columns,
+		Points:  points,
+	}
 }
 
 func (self *influxdbSink) recordWriteFailure() {

--- a/sources/kube_factory.go
+++ b/sources/kube_factory.go
@@ -66,6 +66,7 @@ func CreateKubeSources(master, kubeVersion, clientAuthFile, kubeletPort string, 
 	kubeletApi := datasource.NewKubelet()
 	kubePodsSource := NewKubePodMetrics(kubeletPort, nodesApi, newPodsApi(kubeClient), kubeletApi)
 	kubeNodeSource := NewKubeNodeMetrics(kubeletPort, kubeletApi, nodesApi)
+	kubeEventSource := NewKubeEvents(kubeClient)
 
-	return []api.Source{kubePodsSource, kubeNodeSource}, nil
+	return []api.Source{kubePodsSource, kubeNodeSource, kubeEventSource}, nil
 }


### PR DESCRIPTION
This implements the second part of #118 (follow up to PR #192).

Related Kubernetes Issues:
* GoogleCloudPlatform/kubernetes/issues/4432
* GoogleCloudPlatform/kubernetes/issues/5638

Screenshot showing events in InfluxDB (pulled by heapster from Kubernetes API server and pushed by heapster to influxdb):
![influxdbevents](https://cloud.githubusercontent.com/assets/10052848/6913852/d412860a-d739-11e4-9b8e-5162b7f41370.png)