### PR TITLE
Revert "Use node legacy host ip on older kubernetes versions"

### DIFF
--- a/sources/nodes/kube.go
+++ b/sources/nodes/kube.go
@@ -80,8 +80,6 @@ func (self *kubeNodes) List() (*NodeList, error) {
 				nodeInfo.PublicIP = addr.Address
 			case api.NodeInternalIP:
 				nodeInfo.InternalIP = addr.Address
-			case api.NodeLegacyHostIP:
-				nodeInfo.InternalIP = addr.Address
 			case api.NodeHostName:
 				hostname = addr.Address
 			}


### PR DESCRIPTION
This commit makes heapster use the external ip in GCE.

This reverts commit aa206c499f187984db9761080df7aa01cb0b5627.