### PR TITLE
Use https for kubelet requests.

### DIFF
--- a/sources/datasource/kubelet.go
+++ b/sources/datasource/kubelet.go
@@ -90,7 +90,7 @@ func (self *kubeletSource) getContainer(url string, start, end time.Time, resolu
 }
 
 func (self *kubeletSource) GetContainer(host Host, start, end time.Time, resolution time.Duration) (container *api.Container, err error) {
-	url := fmt.Sprintf("http://%s:%s/%s", host.IP, host.Port, host.Resource)
+	url := fmt.Sprintf("https://%s:%s/%s", host.IP, host.Port, host.Resource)
 	glog.V(3).Infof("about to query kubelet using url: %q", url)
 
 	return self.getContainer(url, start, end, resolution)


### PR DESCRIPTION
We have k8 master calls defaulting to http too. But those can be changed in the flag specifying master ip.