### PR TITLE
Adding filesystem metrics

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 0.11.0 (Unreleased)
+- Export filesystem usage metrics for the node and containers.
+
 ## 0.10.0 (3-30-2014)
 - Downsampling - Resolution of metrics is set to 5s by default.
 - Support for using Kube client auth.

--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -13,6 +13,7 @@ Heapster exports the following metrics to its backends.
 | network/rx_errors  | Cumulative number of errors while receiving over the network                                       | Cumulative | Count       | v0.9            |
 | network/tx         | Cumulative number of bytes sent over the network                                                   | Cumulative | Bytes       | v0.9            |
 | network/tx_errors  | Cumulative number of errors while sending over the network                                         | Cumulative | Count       | v0.9            |
+| filesystem/usage   | Total number of bytes used on a filesystem identified by label 'resource_id'                       | Gauge      | Bytes       | HEAD            |
 
 *Note: Gauge refers to instantaneous metrics*
 
@@ -26,6 +27,7 @@ Heapster tags each metric with the following labels.
 | container_name | User-provided name of the container or full cgroup name for system containers | v0.9            | No                  |
 | labels         | Comma-separated list of user-provided labels. Format is 'key:value'           | v0.9            | Yes                 |
 | hostname       | Hostname where the container ran                                              | v0.9            | No                  |
+| resource_id    | An unique identifier used to differentiate multiple metrics of the same type. e.x. Fs partitions under filesystem/usage | HEAD | No |
 
 
 ## Storage Schema
@@ -41,6 +43,7 @@ The series name is constructed by combining the metric name with its type and un
 ###### Output
 ```
 cpu/usage_ns_cumulative
+filesystem/usage
 memory/page_faults_gauge
 memory/usage_bytes_gauge
 memory/working_set_bytes_gauge

--- a/sinks/api/supported_labels.go
+++ b/sinks/api/supported_labels.go
@@ -19,6 +19,7 @@ const (
 	labelContainerName = "container_name"
 	labelLabels        = "labels"
 	labelHostname      = "hostname"
+	labelResourceID    = "resource_id"
 )
 
 // TODO(vmarmol): Things we should consider adding (note that we only get 10 labels):
@@ -40,6 +41,10 @@ var allLabels = []LabelDescriptor{
 	{
 		Key:         labelHostname,
 		Description: "Hostname where the container ran",
+	},
+	{
+		Key:         labelResourceID,
+		Description: "Identifier(s) specific to a metric",
 	},
 }
 

--- a/sinks/api/supported_metrics.go
+++ b/sinks/api/supported_metrics.go
@@ -168,7 +168,7 @@ var statMetrics = []SupportedStatMetric{
 			return spec.HasFilesystem
 		},
 		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
-			result := make([]internalPoint, 0, len(stats.Filesystem))
+			result := make([]internalPoint, 0, len(stat.Filesystem))
 			for _, fs := range stat.Filesystem {
 				result = append(result, internalPoint{
 					value: int64(fs.Usage),

--- a/sinks/api/supported_metrics.go
+++ b/sinks/api/supported_metrics.go
@@ -32,8 +32,8 @@ var statMetrics = []SupportedStatMetric{
 		HasValue: func(spec *cadvisor.ContainerSpec) bool {
 			return !spec.CreationTime.IsZero()
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) interface{} {
-			return time.Since(spec.CreationTime).Nanoseconds() / time.Millisecond.Nanoseconds()
+		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			return []internalPoint{{value: time.Since(spec.CreationTime).Nanoseconds() / time.Millisecond.Nanoseconds()}}
 		},
 	},
 	{
@@ -47,8 +47,8 @@ var statMetrics = []SupportedStatMetric{
 		HasValue: func(spec *cadvisor.ContainerSpec) bool {
 			return spec.HasCpu
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) interface{} {
-			return int64(stat.Cpu.Usage.Total)
+		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			return []internalPoint{{value: int64(stat.Cpu.Usage.Total)}}
 		},
 	},
 	{
@@ -62,8 +62,8 @@ var statMetrics = []SupportedStatMetric{
 		HasValue: func(spec *cadvisor.ContainerSpec) bool {
 			return spec.HasMemory
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) interface{} {
-			return int64(stat.Memory.Usage)
+		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			return []internalPoint{{value: int64(stat.Memory.Usage)}}
 		},
 	},
 	{
@@ -77,8 +77,8 @@ var statMetrics = []SupportedStatMetric{
 		HasValue: func(spec *cadvisor.ContainerSpec) bool {
 			return spec.HasMemory
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) interface{} {
-			return int64(stat.Memory.WorkingSet)
+		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			return []internalPoint{{value: int64(stat.Memory.WorkingSet)}}
 		},
 	},
 	{
@@ -92,8 +92,8 @@ var statMetrics = []SupportedStatMetric{
 		HasValue: func(spec *cadvisor.ContainerSpec) bool {
 			return spec.HasMemory
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) interface{} {
-			return int64(stat.Memory.ContainerData.Pgfault)
+		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			return []internalPoint{{value: int64(stat.Memory.ContainerData.Pgfault)}}
 		},
 	},
 	{
@@ -107,8 +107,8 @@ var statMetrics = []SupportedStatMetric{
 		HasValue: func(spec *cadvisor.ContainerSpec) bool {
 			return spec.HasNetwork
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) interface{} {
-			return int64(stat.Network.RxBytes)
+		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			return []internalPoint{{value: int64(stat.Network.RxBytes)}}
 		},
 	},
 	{
@@ -122,8 +122,8 @@ var statMetrics = []SupportedStatMetric{
 		HasValue: func(spec *cadvisor.ContainerSpec) bool {
 			return spec.HasNetwork
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) interface{} {
-			return int64(stat.Network.RxErrors)
+		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			return []internalPoint{{value: int64(stat.Network.RxErrors)}}
 		},
 	},
 	{
@@ -137,8 +137,8 @@ var statMetrics = []SupportedStatMetric{
 		HasValue: func(spec *cadvisor.ContainerSpec) bool {
 			return spec.HasNetwork
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) interface{} {
-			return int64(stat.Network.TxBytes)
+		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			return []internalPoint{{value: int64(stat.Network.TxBytes)}}
 		},
 	},
 	{
@@ -152,12 +152,36 @@ var statMetrics = []SupportedStatMetric{
 		HasValue: func(spec *cadvisor.ContainerSpec) bool {
 			return spec.HasNetwork
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) interface{} {
-			return int64(stat.Network.TxErrors)
+		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			return []internalPoint{{value: int64(stat.Network.TxErrors)}}
 		},
 	},
+	{
+		MetricDescriptor: MetricDescriptor{
+			Name:        "filesystem/usage",
+			Description: "Total number of bytes consumed on a filesystem",
+			Type:        MetricGauge,
+			ValueType:   ValueInt64,
+			Units:       UnitsCount,
+		},
+		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+			return spec.HasFilesystem
+		},
+		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			result := make([]internalPoint, 0, len(stats.Filesystem))
+			for _, fs := range stat.Filesystem {
+				result = append(result, internalPoint{
+					value: int64(fs.Usage),
+					labels: map[string]string{
+						labelResourceID: fs.Device,
+					},
+				})
+			}
+			return result
+		},
+	},
+
 	// TODO(vmarmol): DiskIO stats if we find those useful and know how to export them in a user-friendly way.
-	// TODO(vmarmol): FS usage. That requires more labels that the rest here so we will need a new function.
 }
 
 // TODO: Add Status metrics - restarts, OOMs, etc.

--- a/sinks/api/types.go
+++ b/sinks/api/types.go
@@ -129,6 +129,14 @@ type Point struct {
 	Value interface{}
 }
 
+// internalPoint is an internal object.
+type internalPoint struct {
+	// Overrides any default labels generated for every Point.
+	// This is typically used for metric specific labels like 'resource_id'.
+	labels map[string]string
+	value  interface{}
+}
+
 // SupportedStatMetric represents a resource usage stat metric.
 type SupportedStatMetric struct {
 	MetricDescriptor
@@ -136,8 +144,8 @@ type SupportedStatMetric struct {
 	// Returns whether this metric is present.
 	HasValue func(*cadvisor.ContainerSpec) bool
 
-	// Returns the desired data point for this metric from the stats.
-	GetValue func(*cadvisor.ContainerSpec, *cadvisor.ContainerStats) interface{}
+	// Returns a slice of internal point objects that contain metric values and associated labels.
+	GetValue func(*cadvisor.ContainerSpec, *cadvisor.ContainerStats) []internalPoint
 }
 
 // Timeseries represents a single metric.


### PR DESCRIPTION
Note that support in cadvisor for docker container fs metrics is not complete. 

@vmarmol @rjnagal: I have chosen 'resource_id' as the label to uniquely identify sub-resource types like network cards and filesystem partitions. Any thoughts?