### PR TITLE
Easier pluggable sources & multiple sources on cmd line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 heapster
 .cover
+extpoints/extpoints.go
 
 # Vim-related files
 [._]*.s[a-w][a-z]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 all: build
 
-build: 	
+deps:
+	go get github.com/progrium/go-extpoints
+
+build: clean deps
 	go generate github.com/GoogleCloudPlatform/heapster
 	godep go build -a github.com/GoogleCloudPlatform/heapster
 
@@ -9,11 +12,11 @@ sanitize:
 	hooks/check_gofmt.sh
 	hooks/run_vet.sh
 
-test-unit: clean sanitize build 
+test-unit: clean sanitize build
 	godep go test --test.short github.com/GoogleCloudPlatform/heapster/...
 
 test-unit-cov: clean sanitize build
-	hooks/coverage.sh	
+	hooks/coverage.sh
 
 container: build
 	cp ./heapster ./deploy/docker/heapster

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Internally, heapster uses [cAdvisor](https://github.com/google/cadvisor) for com
 Heapster currently supports [Kubernetes](https://github.com/GoogleCloudPlatform/kubernetes) and CoreOS natively. It can be extended to support other cluster management solutions easily.
 While running in a Kube cluster, heapster collects compute resource usage of all pods and nodes.
 
+Source configuration is documented [here](docs/source-configuration.md).
+
 ### Running Heapster on Kubernetes
 Heapster supports a pluggable storage backend. It supports [InfluxDB](http://influxdb.com) with [Grafana](http://grafana.org/docs/features/influxdb) and [Google Cloud Monitoring](https://cloud.google.com/monitoring/). We welcome patches that add additional storage backends.
 

--- a/deploy/docker/run.sh
+++ b/deploy/docker/run.sh
@@ -8,7 +8,7 @@ fi
 
 # If in Kubernetes, target the master.
 if [ ! -z $KUBERNETES_RO_SERVICE_HOST ]; then
-  EXTRA_ARGS="--kubernetes_master ${KUBERNETES_RO_SERVICE_HOST}:${KUBERNETES_RO_SERVICE_PORT} $EXTRA_ARGS"
+  EXTRA_ARGS="--source=kubernetes:http://${KUBERNETES_RO_SERVICE_HOST}:${KUBERNETES_RO_SERVICE_PORT} $EXTRA_ARGS"
 fi
 
 HEAPSTER="/usr/bin/heapster"

--- a/docs/source-configuration.md
+++ b/docs/source-configuration.md
@@ -1,0 +1,59 @@
+Configuring sources
+===================
+
+Heapster can get data from multiple sources. These are specified on the command line
+via the `--source` flag. The flag takes an argument of the form `PREFIX:CONFIG[?OPTIONS]`.
+Options (optional!) are specified as URL query parameters, separated by `&` as normal.
+This allows each source to have custom configuration passed to it without needing to
+continually add new flags to Heapster as new sources are added. This also means
+heapster can capture metrics from multiple sources at once, potentially even multiple
+Kubernetes clusters.
+
+## Current sources
+### Kubernetes
+To use the kubernetes source add the following flag:
+
+```
+--source=kubernetes:<KUBERNETES_MASTER>[?<KUBERNETES_OPTIONS>]
+```
+
+If you're running Heapster in a Kubernetes pod you can use the following flag:
+
+```
+--source=kubernetes:https://kubernetes-ro
+```
+
+The following options are available:
+
+* `apiVersion` - API version to use to talk to Kubernetes (default: `v1beta1`)
+* `insecure` - whether to trust kubernetes certificates (default: `false`)
+* `kubeletPort` - kubelet port to use (default: `10250`)
+* `auth` - client auth file to use (no default)
+
+### Cadvisor
+Cadvisor source comes in two types: standalone & CoreOS:
+
+#### External
+External cadvisor source "discovers" hosts from the specified file. Use it like this:
+
+```
+--source=cadvisor:external[?<OPTIONS>]
+```
+
+The following options are available:
+
+* `standalone` - only use `localhost` (default: `false`)
+* `hostsFile` - file containing list of hosts to gather cadvisor metrics from (default: `/var/run/heapster/hosts`)
+* `cadvisorPort` - cadvisor port to use (default: `8080`)
+
+#### CoreOS
+CoreOS cadvisor source discovers nodes from the specified fleet endpoints. Use it like this:
+
+```
+--source=cadvisor:coreos[?<OPTIONS>]
+```
+
+The following options are available:
+
+* `fleetEndpoint` - fleet endpoints to use. This can be specified multiple times (no default)
+* `cadvisorPort` - cadvisor port to use (default: `8080`)

--- a/extpoints/interfaces.go
+++ b/extpoints/interfaces.go
@@ -1,0 +1,19 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extpoints
+
+import "github.com/GoogleCloudPlatform/heapster/sources/api"
+
+type SourceFactory func(string, map[string][]string) ([]api.Source, error)

--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,28 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+type Uris []string
+
+func (s *Uris) String() string {
+	return fmt.Sprintf("%v", *s)
+}
+
+func (s *Uris) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}

--- a/heapster.go
+++ b/heapster.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:generate go-extpoints
 package main
 
 import (
@@ -36,10 +37,12 @@ var (
 	argPort            = flag.Int("port", 8082, "port to listen")
 	argIp              = flag.String("listen_ip", "", "IP to listen on, defaults to all IPs")
 	argMaxProcs        = flag.Int("max_procs", 0, "max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores).")
+	argSources         Uris
 )
 
 func main() {
 	defer glog.Flush()
+	flag.Var(&argSources, "source", "source(s) to watch")
 	flag.Parse()
 	setMaxProcs()
 	glog.Infof(strings.Join(os.Args, " "))

--- a/integration/.jenkins.sh
+++ b/integration/.jenkins.sh
@@ -3,6 +3,7 @@ set -x
 
 export GOPATH="$JENKINS_HOME/workspace/project"
 export GOBIN="$GOPATH/bin"
+export PATH="$GOBIN:$PATH"
 
 if ! git diff --name-only origin/master | grep -c -E "*.go|*.sh|.*yaml" &> /dev/null; then
   echo "This PR does not touch files that require integration testing. Skipping integration tests!"
@@ -12,5 +13,7 @@ fi
 SUPPORTED_KUBE_VERSIONS="0.14.1"
 TEST_NAMESPACE="default"
 
+go get github.com/progrium/go-extpoints
+go generate
 cd integration
 godep go test -a -v --vmodule=*=1 --timeout=30m --namespace=$TEST_NAMESPACE --kube_versions=$SUPPORTED_KUBE_VERSIONS github.com/GoogleCloudPlatform/heapster/...

--- a/modules.go
+++ b/modules.go
@@ -1,0 +1,19 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	_ "github.com/GoogleCloudPlatform/heapster/sources"
+)

--- a/sources/cadvisor_test.go
+++ b/sources/cadvisor_test.go
@@ -43,7 +43,7 @@ func TestBasicSuccess(t *testing.T) {
 
 	source := &cadvisorSource{
 		nodesApi:     &fakeNodesApi{nodes.NodeList{}},
-		cadvisorPort: "8080",
+		cadvisorPort: 8080,
 		cadvisorApi:  cadvisorApi,
 	}
 	data, err := source.GetInfo(time.Now(), time.Now().Add(time.Minute), time.Second)
@@ -56,8 +56,8 @@ func TestWorkflowSuccess(t *testing.T) {
 		subcontainers []*api.Container
 		root          *api.Container
 	}
-	hostA := datasource.Host{IP: "1.1.1.1", Port: "8080", Resource: ""}
-	hostB := datasource.Host{IP: "1.1.1.2", Port: "8080", Resource: ""}
+	hostA := datasource.Host{IP: "1.1.1.1", Port: 8080, Resource: ""}
+	hostB := datasource.Host{IP: "1.1.1.2", Port: 8080, Resource: ""}
 	expectedData := map[datasource.Host]cadvisorData{
 		hostA: {
 			subcontainers: []*api.Container{{Name: "/a"}},
@@ -85,7 +85,7 @@ func TestWorkflowSuccess(t *testing.T) {
 	}
 	source := &cadvisorSource{
 		nodesApi:     &fakeNodesApi{nodeList},
-		cadvisorPort: "8080",
+		cadvisorPort: 8080,
 		cadvisorApi:  cadvisorApi,
 	}
 	data, err := source.GetInfo(time.Now(), time.Now().Add(time.Minute), time.Second)

--- a/sources/datasource/cadvisor.go
+++ b/sources/datasource/cadvisor.go
@@ -63,7 +63,7 @@ func (self *cadvisorSource) getAllContainers(client *cadvisorClient.Client, star
 }
 
 func (self *cadvisorSource) GetAllContainers(host Host, start, end time.Time, resolution time.Duration) (subcontainers []*api.Container, root *api.Container, err error) {
-	url := fmt.Sprintf("http://%s:%s/", host.IP, host.Port)
+	url := fmt.Sprintf("http://%s:%d/", host.IP, host.Port)
 	client, err := cadvisorClient.NewClient(url)
 	if err != nil {
 		return

--- a/sources/datasource/kubelet.go
+++ b/sources/datasource/kubelet.go
@@ -90,7 +90,7 @@ func (self *kubeletSource) getContainer(url string, start, end time.Time, resolu
 }
 
 func (self *kubeletSource) GetContainer(host Host, start, end time.Time, resolution time.Duration) (container *api.Container, err error) {
-	url := fmt.Sprintf("http://%s:%s/%s", host.IP, host.Port, host.Resource)
+	url := fmt.Sprintf("http://%s:%d/%s", host.IP, host.Port, host.Resource)
 	glog.V(3).Infof("about to query kubelet using url: %q", url)
 
 	return self.getContainer(url, start, end, resolution)

--- a/sources/datasource/types.go
+++ b/sources/datasource/types.go
@@ -22,7 +22,7 @@ import (
 
 type Host struct {
 	IP       string
-	Port     string
+	Port     int
 	Resource string
 }
 

--- a/sources/kube_nodes.go
+++ b/sources/kube_nodes.go
@@ -27,11 +27,11 @@ import (
 
 type kubeNodeMetrics struct {
 	kubeletApi  datasource.Kubelet
-	kubeletPort string
+	kubeletPort int
 	nodesApi    nodes.NodesApi
 }
 
-func NewKubeNodeMetrics(kubeletPort string, kubeletApi datasource.Kubelet, nodesApi nodes.NodesApi) api.Source {
+func NewKubeNodeMetrics(kubeletPort int, kubeletApi datasource.Kubelet, nodesApi nodes.NodesApi) api.Source {
 	return &kubeNodeMetrics{
 		kubeletApi:  kubeletApi,
 		kubeletPort: kubeletPort,

--- a/sources/kube_pods.go
+++ b/sources/kube_pods.go
@@ -27,7 +27,7 @@ import (
 )
 
 type kubePodsSource struct {
-	kubeletPort string
+	kubeletPort int
 	nodesApi    nodes.NodesApi
 	podsApi     podsApi
 	kubeletApi  datasource.Kubelet
@@ -35,7 +35,7 @@ type kubePodsSource struct {
 	podErrors   map[podInstance]int // guarded by stateLock
 }
 
-func NewKubePodMetrics(kubeletPort string, nodesApi nodes.NodesApi, podsApi podsApi, kubeletApi datasource.Kubelet) api.Source {
+func NewKubePodMetrics(kubeletPort int, nodesApi nodes.NodesApi, podsApi podsApi, kubeletApi datasource.Kubelet) api.Source {
 	return &kubePodsSource{
 		kubeletPort: kubeletPort,
 		kubeletApi:  kubeletApi,

--- a/sources/kube_pods_test.go
+++ b/sources/kube_pods_test.go
@@ -38,7 +38,7 @@ func (self *fakePodsApi) DebugInfo() string {
 func TestKubePodMetricsBasic(t *testing.T) {
 	nodesApi := &fakeNodesApi{nodes.NodeList{}}
 	podsApi := &fakePodsApi{[]api.Pod{}}
-	source := NewKubePodMetrics("10250", nodesApi, podsApi, &fakeKubeletApi{nil})
+	source := NewKubePodMetrics(10250, nodesApi, podsApi, &fakeKubeletApi{nil})
 	_, err := source.GetInfo(time.Now(), time.Now().Add(time.Minute), time.Second)
 	require.NoError(t, err)
 	require.NotEmpty(t, source.DebugInfo())
@@ -65,7 +65,7 @@ func TestKubePodMetricsFull(t *testing.T) {
 	nodesApi := &fakeNodesApi{nodeList}
 	podsApi := &fakePodsApi{podList}
 	kubeletApi := &fakeKubeletApi{container}
-	source := NewKubePodMetrics("10250", nodesApi, podsApi, kubeletApi)
+	source := NewKubePodMetrics(10250, nodesApi, podsApi, kubeletApi)
 	data, err := source.GetInfo(time.Now(), time.Now().Add(time.Minute), time.Second)
 	require.NoError(t, err)
 	require.NotEmpty(t, data)

--- a/sources/nodes/coreos.go
+++ b/sources/nodes/coreos.go
@@ -15,11 +15,9 @@
 package nodes
 
 import (
-	"flag"
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	fleetClient "github.com/coreos/fleet/client"
@@ -28,8 +26,6 @@ import (
 	"github.com/coreos/fleet/registry"
 	"github.com/golang/glog"
 )
-
-var argFleetEndpoints = flag.String("fleet_endpoints", "http://127.0.0.1:4001", "Comma separated list of fleet server endpoints")
 
 const etcdRegistry = "/_coreos.com/fleet/"
 
@@ -89,11 +85,8 @@ func getFleetRegistryClient(fleetEndpoints []string) (fleetClient.API, error) {
 	return &fleetClient.RegistryClient{Registry: reg}, nil
 }
 
-func NewCoreOSNodes() (NodesApi, error) {
-	if *argFleetEndpoints == "" {
-		return nil, fmt.Errorf("fleet_endpoint flag invalid.")
-	}
-	client, err := getFleetRegistryClient(strings.Split(*argFleetEndpoints, ","))
+func NewCoreOSNodes(fleetEndpoints []string) (NodesApi, error) {
+	client, err := getFleetRegistryClient(fleetEndpoints)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get fleet client - %q", err)
 	}

--- a/sources/nodes/external.go
+++ b/sources/nodes/external.go
@@ -16,7 +16,6 @@ package nodes
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -35,10 +34,6 @@ type externalCadvisorNodes struct {
 
 	nodes *NodeList
 }
-
-// While updating this, also update deploy/docker/Dockerfile.
-var hostsFile = flag.String("external_hosts_file", "/var/run/heapster/hosts", "A file that heapster refers to get a list of nodes to monitor.")
-var standaloneMode = flag.Bool("standalone", false, "Whether to run Heapster in \"standalone\" mode where it only targets the current node.")
 
 func (self *externalCadvisorNodes) List() (*NodeList, error) {
 	// Standalone means only localhost.
@@ -88,19 +83,19 @@ func (self *externalCadvisorNodes) DebugInfo() string {
 	return output
 }
 
-func NewExternalNodes() (NodesApi, error) {
-	if *standaloneMode {
+func NewExternalNodes(standaloneMode bool, hostsFile string) (NodesApi, error) {
+	if standaloneMode {
 		glog.Infof("Running in standalone mode, external nodes source will only use localhost")
 	} else {
-		_, err := os.Stat(*hostsFile)
+		_, err := os.Stat(hostsFile)
 		if err != nil {
-			return nil, fmt.Errorf("cannot stat file %q: %s", *hostsFile, err)
+			return nil, fmt.Errorf("cannot stat file %q: %s", hostsFile, err)
 		}
 	}
 
 	return &externalCadvisorNodes{
-		hostsFile:  *hostsFile,
-		standalone: *standaloneMode,
+		hostsFile:  hostsFile,
+		standalone: standaloneMode,
 		nodes:      nil,
 	}, nil
 }

--- a/sources/nodes/external_test.go
+++ b/sources/nodes/external_test.go
@@ -72,8 +72,7 @@ func TestExternalFile(t *testing.T) {
 }
 
 func TestLocalhostMonitoring(t *testing.T) {
-	*standaloneMode = true
-	nodesApi, err := NewExternalNodes()
+	nodesApi, err := NewExternalNodes(true, "")
 	require.NoError(t, err)
 
 	const (


### PR DESCRIPTION
Fixes #197.

This PR switches to an easier way to create pluggable sources as well as allowing for multiple sources on the command line if required. Following @vishh's refactoring to source factories, this is the next logical step IMO, allowing source factories to be registered & then created in  a consistent way. This makes it easier for sources to be contributed without the need to add command line flags for each new source.

Sources are configured on the command line via the flag:

    --source=<registered_source_prefix>:<source_uri>?<source_options>

The `--source` flag can be specified multiple times if necessary.

As a concrete example, if you are using the `kubernetes` source you would specify:

    --source=kubernetes:https://localhost:8443?insecure=true

Each source is identified with a prefix such as `kubernetes` or `cadvisor` which is registered in the `SourceFactories` registry in the `extpoints` package.

CoreOS & external cadvisor sources are added in the same way:

    --source=cadvisor:external?standalone=true
    --source=cadvisor:coreos?fleet-endpoint=http://myserver:4001

This PR covers all existing functionality for both coreos & external cadvisor sources as well as kubernetes source.

Once we work through this PR I would like to do the same for sinks.