### PR TITLE
Add code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 heapster
+.cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ install:
 before_script:
  - go get golang.org/x/tools/cmd/vet
  - go get github.com/kr/godep
+ - go get github.com/axw/gocov/gocov
+ - go get golang.org/x/tools/cmd/cover
+ - go get github.com/mattn/goveralls
 script:
  - export PATH=$PATH:$HOME/gopath/bin
  - ./hooks/check_boilerplate.sh
- - gofmt -l `find . -type f -name "*.go" | grep -v Godeps`
+ - formatted="$(go fmt ./...)" && ( ( [[ -n $formatted ]] && echo "gofmt failed on the following files:" && echo -ne $formatted && exit 1) || (( [[ -z $formatted ]] && echo "gofmt passed") ) )
  - go vet github.com/GoogleCloudPlatform/heapster/...
  - godep go build -a github.com/GoogleCloudPlatform/heapster/...
- - godep go test -a -test.short ./... 
+ - ./hooks/coverage.sh

--- a/hooks/coverage.sh
+++ b/hooks/coverage.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Generate test coverage statistics for Go packages.
+#
+# Works around the fact that `go test -coverprofile` currently does not work
+# with multiple packages, see https://code.google.com/p/go/issues/detail?id=6909
+#
+# Usage: script/coverage [--html|--coveralls]
+#
+#     --html      Additionally create HTML report and open it in browser
+#     --coveralls Push coverage statistics to coveralls.io
+#
+
+set -e
+
+workdir=.cover
+profile="$workdir/cover.out"
+mode=count
+
+generate_cover_data() {
+    rm -rf "$workdir"
+    mkdir "$workdir"
+
+    for pkg in "$@"; do
+        f="$workdir/$(echo $pkg | tr / -).cover"
+        godep go test -test.short -covermode="$mode" -coverprofile="$f" "$pkg"
+    done
+
+    echo "mode: $mode" >"$profile"
+    grep -h -v "^mode:" "$workdir"/*.cover >>"$profile"
+}
+
+show_cover_report() {
+    godep go tool cover -${1}="$profile"
+}
+
+push_to_coveralls() {
+    echo "Pushing coverage statistics to coveralls.io"
+    goveralls -coverprofile="$profile" -service=travis-ci -repotoken $COVERALLS_TOKEN
+}
+
+generate_cover_data $(godep go list ./...)
+show_cover_report func
+case "$1" in
+"")
+    ;;
+--html)
+    show_cover_report html ;;
+--coveralls)
+    push_to_coveralls ;;
+*)
+    echo >&2 "error: invalid option: $1"; exit 1 ;;
+esac


### PR DESCRIPTION
This PR adds code coverage script that will be run on travis when the build runs. Good to know details like this going forward. We can also use https://coveralls.io by specifying a coveralls token & coveralls will feed back to PRs if configured to.

Also updated gofmt script line to fail build if any files needed go fmt'ing - before this would have just been info but passed.