### PR TITLE
Fix metrics decoder uptime test

### DIFF
--- a/sinks/api/supported_metrics.go
+++ b/sinks/api/supported_metrics.go
@@ -20,6 +20,9 @@ import (
 	cadvisor "github.com/google/cadvisor/info/v1"
 )
 
+// Stub out for testing
+var timeSince = time.Since
+
 var statMetrics = []SupportedStatMetric{
 	{
 		MetricDescriptor: MetricDescriptor{
@@ -33,7 +36,7 @@ var statMetrics = []SupportedStatMetric{
 			return !spec.CreationTime.IsZero()
 		},
 		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
-			return []internalPoint{{value: time.Since(spec.CreationTime).Nanoseconds() / time.Millisecond.Nanoseconds()}}
+			return []internalPoint{{value: timeSince(spec.CreationTime).Nanoseconds() / time.Millisecond.Nanoseconds()}}
 		},
 	},
 	{


### PR DESCRIPTION
A couple of fixes:
* Expected and actual were flipped.
* Uptime test was calling `time.Since` and comparing to a `time.Since` value generated in the code without fixing the creation or current times. It works most of the time because the delta is usually 0, but is  non-deterministic.
