### PR TITLE
Heapster sink events to InfluxDB

### DIFF
--- a/sinks/api/decoder.go
+++ b/sinks/api/decoder.go
@@ -51,9 +51,10 @@ func (self *defaultDecoder) Timeseries(input source_api.AggregateData) ([]Timese
 // Generate the labels.
 func (self *defaultDecoder) getPodLabels(pod *source_api.Pod) map[string]string {
 	labels := make(map[string]string)
-	labels[labelPodId] = pod.ID
-	labels[labelLabels] = LabelsToString(pod.Labels, ",")
-	labels[labelHostname] = pod.Hostname
+	labels[LabelPodId] = pod.ID
+	labels[LabelPodName] = pod.Name
+	labels[LabelLabels] = LabelsToString(pod.Labels, ",")
+	labels[LabelHostname] = pod.Hostname
 
 	return labels
 }
@@ -73,7 +74,7 @@ func (self *defaultDecoder) getContainerSliceMetrics(containers []source_api.Con
 	labels := make(map[string]string)
 	var result []Timeseries
 	for index := range containers {
-		labels[labelHostname] = containers[index].Hostname
+		labels[LabelHostname] = containers[index].Hostname
 		result = append(result, self.getContainerMetrics(&containers[index], copyLabels(labels))...)
 	}
 
@@ -92,7 +93,7 @@ func (self *defaultDecoder) getContainerMetrics(container *source_api.Container,
 	if container == nil {
 		return nil
 	}
-	labels[labelContainerName] = container.Name
+	labels[LabelContainerName] = container.Name
 	// One metric value per data point.
 	var result []Timeseries
 	labelsAsString := LabelsToString(labels, ",")

--- a/sinks/api/decoder_test.go
+++ b/sinks/api/decoder_test.go
@@ -175,7 +175,7 @@ func TestRealInput(t *testing.T) {
 			case "filesystem/usage":
 				value, ok := entry.Point.Value.(int64)
 				require.True(t, ok)
-				name, ok := entry.Point.Labels[labelResourceID]
+				name, ok := entry.Point.Labels[LabelResourceID]
 				require.True(t, ok)
 				assert.Equal(t, expectedFsStats[name], value)
 			default:
@@ -207,10 +207,10 @@ func TestPodLabelsProcessing(t *testing.T) {
 	}
 
 	expectedLabels := map[string]string{
-		labelPodId:         "123",
-		labelLabels:        getLabelsAsString(podLabels),
-		labelHostname:      "1.2.3.4",
-		labelContainerName: "blah",
+		LabelPodId:         "123",
+		LabelLabels:        getLabelsAsString(podLabels),
+		LabelHostname:      "1.2.3.4",
+		LabelContainerName: "blah",
 	}
 	input := source_api.AggregateData{
 		Pods: pods,
@@ -228,8 +228,8 @@ func TestPodLabelsProcessing(t *testing.T) {
 
 func TestContainerLabelsProcessing(t *testing.T) {
 	expectedLabels := map[string]string{
-		labelHostname:      "1.2.3.4",
-		labelContainerName: "blah",
+		LabelHostname:      "1.2.3.4",
+		LabelContainerName: "blah",
 	}
 	container := getContainer("blah")
 	container.Hostname = "1.2.3.4"

--- a/sinks/api/supported_labels.go
+++ b/sinks/api/supported_labels.go
@@ -15,11 +15,12 @@
 package api
 
 const (
-	labelPodId         = "pod_id"
-	labelContainerName = "container_name"
-	labelLabels        = "labels"
-	labelHostname      = "hostname"
-	labelResourceID    = "resource_id"
+	LabelPodId         = "pod_id"
+	LabelPodName       = "pod_name"
+	LabelContainerName = "container_name"
+	LabelLabels        = "labels"
+	LabelHostname      = "hostname"
+	LabelResourceID    = "resource_id"
 )
 
 // TODO(vmarmol): Things we should consider adding (note that we only get 10 labels):
@@ -27,23 +28,27 @@ const (
 // - Namespace: Are IDs unique only per namespace? If so, mangle it into the ID.
 var allLabels = []LabelDescriptor{
 	{
-		Key:         labelPodId,
+		Key:         LabelPodId,
 		Description: "The unique ID of the pod",
 	},
 	{
-		Key:         labelContainerName,
+		Key:         LabelPodName,
+		Description: "The name of the pod",
+	},
+	{
+		Key:         LabelContainerName,
 		Description: "User-provided name of the container or full container name for system containers",
 	},
 	{
-		Key:         labelLabels,
+		Key:         LabelLabels,
 		Description: "Comma-separated list of user-provided labels",
 	},
 	{
-		Key:         labelHostname,
+		Key:         LabelHostname,
 		Description: "Hostname where the container ran",
 	},
 	{
-		Key:         labelResourceID,
+		Key:         LabelResourceID,
 		Description: "Identifier(s) specific to a metric",
 	},
 }

--- a/sinks/api/supported_metrics.go
+++ b/sinks/api/supported_metrics.go
@@ -176,7 +176,7 @@ var statMetrics = []SupportedStatMetric{
 				result = append(result, internalPoint{
 					value: int64(fs.Usage),
 					labels: map[string]string{
-						labelResourceID: fs.Device,
+						LabelResourceID: fs.Device,
 					},
 				})
 			}

--- a/sinks/api/types.go
+++ b/sinks/api/types.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	source_api "github.com/GoogleCloudPlatform/heapster/sources/api"
+	kube_api "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	cadvisor "github.com/google/cadvisor/info/v1"
 )
 
@@ -162,8 +163,9 @@ type ExternalSink interface {
 	// Support input types are as follows:
 	// 1. []Timeseries
 	// TODO: Add map[string]string to support storing raw data like node or pod status, spec, etc.
-	// TODO: Add events.
 	StoreTimeseries([]Timeseries) error
+	// Stores events into the backend.
+	StoreEvents([]kube_api.Event) error
 	// Returns debug information specific to the sink.
 	DebugInfo() string
 }

--- a/sinks/external.go
+++ b/sinks/external.go
@@ -81,6 +81,11 @@ func (self *externalSinkManager) Store(input interface{}) error {
 		if err := externalSink.StoreTimeseries(timeseries); err != nil {
 			errors = append(errors, err)
 		}
+		if data.Events != nil && len(data.Events) > 0 {
+			if err := externalSink.StoreEvents(data.Events); err != nil {
+				errors = append(errors, err)
+			}
+		}
 	}
 	err = nil
 	if len(errors) > 0 {

--- a/sinks/gcm/driver.go
+++ b/sinks/gcm/driver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcloud-golang/compute/metadata"
 	sink_api "github.com/GoogleCloudPlatform/heapster/sinks/api"
 	"github.com/GoogleCloudPlatform/heapster/util/gcstore"
+	kube_api "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/golang/glog"
 )
 
@@ -198,6 +199,12 @@ type lastValueData struct {
 
 // The largest number of timeseries we can write to per request.
 const maxTimeseriesPerRequest = 200
+
+// Stores events into the backend.
+func (self *gcmSink) StoreEvents([]kube_api.Event) error {
+	// No-op, Google Cloud Metrics doesn't store events
+	return nil
+}
 
 // Pushes the specified metric values in input. The metrics must already exist.
 func (self *gcmSink) StoreTimeseries(input []sink_api.Timeseries) error {

--- a/sinks/influxdb/driver_test.go
+++ b/sinks/influxdb/driver_test.go
@@ -1,0 +1,189 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package influxdb
+
+import (
+	"testing"
+
+	sink_api "github.com/GoogleCloudPlatform/heapster/sinks/api"
+	kube_api "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kube_time "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	influxdb "github.com/influxdb/influxdb/client"
+	"github.com/stretchr/testify/assert"
+)
+
+type capturedWriteCall struct {
+	series        []*influxdb.Series
+	timePrecision influxdb.TimePrecision
+}
+
+type fakeInfluxDBClient struct {
+	capturedWriteCalls []capturedWriteCall
+}
+
+func NewFakeInfluxDBClient() *fakeInfluxDBClient {
+	return &fakeInfluxDBClient{[]capturedWriteCall{}}
+}
+
+func (sink *fakeInfluxDBClient) WriteSeriesWithTimePrecision(series []*influxdb.Series, timePrecision influxdb.TimePrecision) error {
+	sink.capturedWriteCalls = append(sink.capturedWriteCalls, capturedWriteCall{series, timePrecision})
+	return nil
+}
+
+func (sink *fakeInfluxDBClient) GetDatabaseList() ([]map[string]interface{}, error) {
+	// No-op
+	return nil, nil
+}
+
+func (sink *fakeInfluxDBClient) CreateDatabase(name string) error {
+	// No-op
+	return nil
+}
+
+func (sink *fakeInfluxDBClient) DisableCompression() {
+	// No-op
+}
+
+type fakeInfluxDBSink struct {
+	sink_api.ExternalSink
+	fakeClient *fakeInfluxDBClient
+}
+
+// Returns a fake influxdb sink.
+func NewFakeSink(avoidColumns bool) fakeInfluxDBSink {
+	client := NewFakeInfluxDBClient()
+	return fakeInfluxDBSink{
+		&influxdbSink{
+			hostname:     "hostname",
+			database:     "databaseName",
+			client:       client,
+			dbName:       "databaseName",
+			avoidColumns: avoidColumns,
+			seqNum:       newMetricSequenceNum(),
+		},
+		client,
+	}
+}
+
+func TestStoreEventsNilInput(t *testing.T) {
+	// Arrange
+	fakeSink := NewFakeSink(false /* avoidColumns */)
+
+	// Act
+	err := fakeSink.StoreEvents(nil /*events*/)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, 0 /* expected */, len(fakeSink.fakeClient.capturedWriteCalls) /* actual */)
+}
+
+func TestStoreEventsEmptyInput(t *testing.T) {
+	// Arrange
+	fakeSink := NewFakeSink(false /* avoidColumns */)
+
+	// Act
+	err := fakeSink.StoreEvents([]kube_api.Event{})
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, 0 /* expected */, len(fakeSink.fakeClient.capturedWriteCalls) /* actual */)
+}
+
+func TestStoreEventsSingleEventInput(t *testing.T) {
+	// Arrange
+	fakeSink := NewFakeSink(false /* avoidColumns */)
+	eventTime := kube_time.Unix(12345, 0)
+	eventSourceHostname := "event1HostName"
+	eventReason := "event1"
+	events := []kube_api.Event{
+		kube_api.Event{
+			Reason:        eventReason,
+			LastTimestamp: eventTime,
+			Source: kube_api.EventSource{
+				Host: eventSourceHostname,
+			},
+		},
+	}
+
+	// Act
+	err := fakeSink.StoreEvents(events)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, 1 /* expected */, len(fakeSink.fakeClient.capturedWriteCalls) /* actual */)
+	assert.Equal(t, influxdb.Millisecond /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].timePrecision /* actual */)
+	assert.Equal(t, 1 /* expected */, len(fakeSink.fakeClient.capturedWriteCalls[0].series) /* actual */)
+	assert.Equal(t, EventsSeriesName /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Name /* actual */)
+	assert.Equal(t, 6 /* expected */, len(fakeSink.fakeClient.capturedWriteCalls[0].series[0].Columns) /* actual */)
+	assert.Equal(t, 1 /* expected */, len(fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points) /* actual */)
+	assert.Equal(t, eventTime.Unix() /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][0] /* actual */)    // Column 0 - time
+	assert.Equal(t, 0 /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][1] /* actual */)                   // Column 1 - sequence_number
+	assert.Equal(t, "" /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][2] /* actual */)                  // Column 2 - pod_id
+	assert.Equal(t, "" /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][3] /* actual */)                  // Column 3 - pod_id
+	assert.Equal(t, eventSourceHostname /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][4] /* actual */) // Column 4 - pod_id
+	assert.Contains(t, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][5], eventReason)                                  // Column 5 - value
+}
+
+func TestStoreEventsMultipleEventsInput(t *testing.T) {
+	// Arrange
+	fakeSink := NewFakeSink(false /* avoidColumns */)
+	event1Time := kube_time.Unix(12345, 0)
+	event2Time := kube_time.Unix(12366, 0)
+	event1SourceHostname := "event1HostName"
+	event2SourceHostname := "event2HostName"
+	event1Reason := "event1"
+	event2Reason := "event2"
+	events := []kube_api.Event{
+		kube_api.Event{
+			Reason:        event1Reason,
+			LastTimestamp: event1Time,
+			Source: kube_api.EventSource{
+				Host: event1SourceHostname,
+			},
+		},
+		kube_api.Event{
+			Reason:        event2Reason,
+			LastTimestamp: event2Time,
+			Source: kube_api.EventSource{
+				Host: event2SourceHostname,
+			},
+		},
+	}
+
+	// Act
+	err := fakeSink.StoreEvents(events)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, 1 /* expected */, len(fakeSink.fakeClient.capturedWriteCalls) /* actual */)
+	assert.Equal(t, influxdb.Millisecond /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].timePrecision /* actual */)
+	assert.Equal(t, 1 /* expected */, len(fakeSink.fakeClient.capturedWriteCalls[0].series) /* actual */)
+	assert.Equal(t, EventsSeriesName /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Name /* actual */)
+	assert.Equal(t, 6 /* expected */, len(fakeSink.fakeClient.capturedWriteCalls[0].series[0].Columns) /* actual */)
+	assert.Equal(t, 2 /* expected */, len(fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points) /* actual */)
+	assert.Equal(t, event1Time.Unix() /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][0] /* actual */)    // Column 0 - time
+	assert.Equal(t, 0 /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][1] /* actual */)                    // Column 1 - sequence_number
+	assert.Equal(t, "" /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][2] /* actual */)                   // Column 2 - pod_id
+	assert.Equal(t, "" /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][3] /* actual */)                   // Column 3 - pod_id
+	assert.Equal(t, event1SourceHostname /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][4] /* actual */) // Column 4 - pod_id
+	assert.Contains(t, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[0][5], event1Reason)                                  // Column 5 - value
+	assert.Equal(t, event2Time.Unix() /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[1][0] /* actual */)    // Column 0 - time
+	assert.Equal(t, 1 /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[1][1] /* actual */)                    // Column 1 - sequence_number
+	assert.Equal(t, "" /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[1][2] /* actual */)                   // Column 2 - pod_id
+	assert.Equal(t, "" /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[1][3] /* actual */)                   // Column 3 - pod_id
+	assert.Equal(t, event2SourceHostname /* expected */, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[1][4] /* actual */) // Column 4 - pod_id
+	assert.Contains(t, fakeSink.fakeClient.capturedWriteCalls[0].series[0].Points[1][5], event2Reason)                                  // Column 5 - value
+
+}

--- a/sources/kube_factory.go
+++ b/sources/kube_factory.go
@@ -99,6 +99,7 @@ func CreateKubeSources(uri string, options map[string][]string) ([]api.Source, e
 	kubeletApi := datasource.NewKubelet()
 	kubePodsSource := NewKubePodMetrics(kubeletPort, nodesApi, newPodsApi(kubeClient), kubeletApi)
 	kubeNodeSource := NewKubeNodeMetrics(kubeletPort, kubeletApi, nodesApi)
+	kubeEventsSource := NewKubeEvents(kubeClient)
 
-	return []api.Source{kubePodsSource, kubeNodeSource}, nil
+	return []api.Source{kubePodsSource, kubeNodeSource, kubeEventsSource}, nil
 }


### PR DESCRIPTION
This implements the second part of #118 (follow up to PR #192).

Related Kubernetes Issues:
* GoogleCloudPlatform/kubernetes/issues/4432
* GoogleCloudPlatform/kubernetes/issues/5638

Screenshot showing events in InfluxDB (pulled by heapster from Kubernetes API server and pushed by heapster to influxdb):
![influxdbevents07](https://cloud.githubusercontent.com/assets/10052848/7127818/616ca82c-e1fe-11e4-9136-4adeeb72c37e.png)

Branched from #205

CC @vishh 