### PR TITLE
Update v1beta3 configs.

### DIFF
--- a/deploy/kube-config/influxdb/v1beta3/grafana-service.yaml
+++ b/deploy/kube-config/influxdb/v1beta3/grafana-service.yaml
@@ -6,7 +6,8 @@ metadata:
     kubernetes.io/cluster-service: "true"
   name: monitoring-grafana
 spec:
-  targetPort: 8080
-  port: 80
+  ports:
+    - port: 80
+      targetPort: 8080
   selector:
     name: influxGrafana

--- a/deploy/kube-config/influxdb/v1beta3/heapster-service.yaml
+++ b/deploy/kube-config/influxdb/v1beta3/heapster-service.yaml
@@ -6,8 +6,9 @@ metadata:
     kubernetes.io/cluster-service: "true"
   name: monitoring-heapster
 spec:
-  targetPort: 8082
-  port: 80
+  ports:
+    - port: 80
+      targetPort: 8082
   selector:
     name: heapster
     kubernetes.io/cluster-service: "true"

--- a/deploy/kube-config/influxdb/v1beta3/influxdb-grafana-controller.yaml
+++ b/deploy/kube-config/influxdb/v1beta3/influxdb-grafana-controller.yaml
@@ -1,32 +1,32 @@
 apiVersion: v1beta3
 kind: ReplicationController
-metadata:
-  labels:
+metadata: 
+  labels: 
     name: influxGrafana
   name: monitoring-influx-grafana-controller
-spec:
+spec: 
   replicas: 1
-  selector:
+  selector: 
     name: influxGrafana
-  template:
-    metadata:
-      labels:
+  template: 
+    metadata: 
+      labels: 
         name: influxGrafana
-    spec:
-      containers:
-        - image: kubernetes/heapster_influxdb:v0.3
+    spec: 
+      containers: 
+        - 
+          image: "kubernetes/heapster_influxdb:v0.3"
           name: influxdb
-          ports:
-            - containerPort: 8083
-            - containerPort: 8086
-        - name: grafana
-          image: kubernetes/heapster_grafana:v0.6
-          ports:
-              - containerPort: 8080
-          env:
-              - name: "INFLUXDB_EXTERNAL_URL"
-                value: '/api/v1beta1/proxy/services/monitoring-grafana/db/'
-              - name: "INFLUXDB_HOST"
-                value: 'monitoring-influxdb'
-              - name: "INFLUXDB_PORT"
-                value: '80'
+        - 
+          env: 
+            - 
+              name: INFLUXDB_EXTERNAL_URL
+              value: /api/v1beta1/proxy/services/monitoring-grafana/db/
+            - 
+              name: INFLUXDB_HOST
+              value: monitoring-influxdb
+            - 
+              name: INFLUXDB_PORT
+              value: "80"
+          image: "kubernetes/heapster_grafana:v0.6"
+          name: grafana

--- a/deploy/kube-config/influxdb/v1beta3/influxdb-service.yaml
+++ b/deploy/kube-config/influxdb/v1beta3/influxdb-service.yaml
@@ -6,7 +6,8 @@ metadata:
     kubernetes.io/cluster-service: "true"
   name: monitoring-influxdb
 spec:
-  targetPort: 8086
-  port: 80
+  ports:
+    - port: 80
+      targetPort: 8086
   selector:
     name: influxGrafana

--- a/deploy/kube-config/influxdb/v1beta3/influxdb-ui-service.yaml
+++ b/deploy/kube-config/influxdb/v1beta3/influxdb-ui-service.yaml
@@ -4,7 +4,12 @@ metadata:
   labels:
   name: monitoring-influxdb-ui
 spec:
-  targetPort: 8083
-  port: 80
+  ports:
+    - name: http
+      port: 8083
+      targetPort: 8083
+    - name: api
+      port: 8086
+      targetPort: 8086
   selector:
     name: influxGrafana


### PR DESCRIPTION
Once a new kube release is out, I will update the e2e to use the v1beta3 configs by default. For now, the reviewer will have to trust that I tested this config manually!