### PR TITLE
Default kubelet port should be 10250

### DIFF
--- a/sources/kube_factory.go
+++ b/sources/kube_factory.go
@@ -32,7 +32,7 @@ import (
 const (
 	defaultApiVersion  = "v1beta1"
 	defaultInsecure    = false
-	defaultKubeletPort = 10255
+	defaultKubeletPort = 10250
 )
 
 func init() {


### PR DESCRIPTION
The docs say that the defaultKubeletPort is 10250, but it was actually 10255. Kubelet usually binds to port 10250.