### PR TITLE
Support for Hawkular-Metrics sink.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -198,9 +198,17 @@
 			"Rev": "95919286de1ca5a30261fac83b070e736286aae8"
 		},
 		{
+			"ImportPath": "github.com/hawkular/hawkular-client-go/metrics",
+			"Rev": "06bf87e3e131208c321ebd5d21576d94809537a1"
+		},
+		{
 			"ImportPath": "github.com/imdario/mergo",
 			"Comment": "0.1.3-10-g67b9c0a",
 			"Rev": "67b9c0a23d7ee9dcbcd44cd7ece4bf15ef6f4d26"
+		},
+		{
+			"ImportPath": "github.com/hawkular/hawkular-client-go/metrics",
+			"Rev": "0c104b03bf4da56e0d30a1bd63a3ebcf55595d63"
 		},
 		{
 			"ImportPath": "github.com/influxdb/influxdb/client",

--- a/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/client.go
+++ b/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/client.go
@@ -1,0 +1,389 @@
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// TODO: Add statistics support? Error metrics (connection errors, request errors), request metrics:
+// totals, request rate? mean time, avg time, max, min, percentiles etc.. ? And clear metrics..
+// Stateful metrics? Kinda like Counters.Inc(..) ?
+
+// More detailed error
+
+type HawkularClientError struct {
+	msg  string
+	Code int
+}
+
+func (self *HawkularClientError) Error() string {
+	return fmt.Sprintf("Hawkular returned status code %d, error message: %s", self.Code, self.msg)
+}
+
+// Client creation and instance config
+
+const (
+	base_url string = "hawkular/metrics"
+)
+
+type Parameters struct {
+	Tenant string
+	Host   string
+	Path   string // Optional
+}
+
+type Client struct {
+	Tenant string
+	url    *url.URL
+	client *http.Client
+}
+
+func NewHawkularClient(p Parameters) (*Client, error) {
+	if p.Path == "" {
+		p.Path = base_url
+	}
+
+	u := &url.URL{
+		Host:   p.Host,
+		Path:   p.Path,
+		Scheme: "http",
+		Opaque: fmt.Sprintf("//%s/%s", p.Host, p.Path),
+	}
+	return &Client{
+		url:    u,
+		Tenant: p.Tenant,
+		client: &http.Client{},
+	}, nil
+}
+
+// Public functions
+
+// Creates a new metric, and returns true if creation succeeded, false if not (metric was already created).
+// err is returned only in case of another error than 'metric already created'
+func (self *Client) Create(md MetricDefinition) (bool, error) {
+	jsonb, err := json.Marshal(&md)
+	if err != nil {
+		return false, err
+	}
+	err = self.post(self.metricsUrl(md.Type), jsonb)
+	if err != nil {
+		if err, ok := err.(*HawkularClientError); ok {
+			if err.Code != http.StatusConflict {
+				return false, err
+			} else {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+	return true, nil
+
+}
+
+// Fetch metric definitions for one metric type
+func (self *Client) Definitions(t MetricType) ([]*MetricDefinition, error) {
+	q := make(map[string]string)
+	q["type"] = t.shortForm()
+	url, err := self.paramUrl(self.metricsUrl(Generic), q)
+	if err != nil {
+		return nil, err
+	}
+	b, err := self.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	md := []*MetricDefinition{}
+	if b != nil {
+		if err = json.Unmarshal(b, &md); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, m := range md {
+		m.Type = t
+	}
+
+	return md, nil
+}
+
+// Return a single definition
+func (self *Client) Definition(t MetricType, id string) (*MetricDefinition, error) {
+	url := self.singleMetricsUrl(t, id)
+
+	b, err := self.get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	md := MetricDefinition{}
+	if b != nil {
+		if err = json.Unmarshal(b, &md); err != nil {
+			return nil, err
+		}
+	}
+	md.Type = t
+	return &md, nil
+}
+
+// Fetch metric definition tags
+func (self *Client) Tags(t MetricType, id string) (*map[string]string, error) {
+	id_url := self.cleanId(id)
+	b, err := self.get(self.tagsUrl(t, id_url))
+	if err != nil {
+		return nil, err
+	}
+
+	tags := make(map[string]string)
+	// Repetive code.. clean up with other queries to somewhere..
+	if b != nil {
+		if err = json.Unmarshal(b, &tags); err != nil {
+			return nil, err
+		}
+	}
+
+	return &tags, nil
+}
+
+// Replace metric definition tags
+// TODO: Should this be "ReplaceTags" etc?
+func (self *Client) UpdateTags(t MetricType, id string, tags map[string]string) error {
+	id_url := self.cleanId(id)
+	b, err := json.Marshal(tags)
+	if err != nil {
+		return err
+	}
+	return self.put(self.tagsUrl(t, id_url), b)
+}
+
+// Delete given tags from the definition
+func (self *Client) DeleteTags(t MetricType, id_str string, deleted map[string]string) error {
+	id := self.cleanId(id_str)
+	tags := make([]string, 0, len(deleted))
+	for k, v := range deleted {
+		tags = append(tags, fmt.Sprintf("%s:%s", k, v))
+	}
+	j := strings.Join(tags, ",")
+	u := self.tagsUrl(t, id)
+	self.addToUrl(u, j)
+	return self.del(u)
+}
+
+// Take input of single Metric instance. If Timestamp is not defined, use current time
+func (self *Client) PushSingleGaugeMetric(id string, m Datapoint) error {
+	// id = self.cleanId(id)
+
+	if _, ok := m.Value.(float64); !ok {
+		f, err := ConvertToFloat64(m.Value)
+		if err != nil {
+			return err
+		}
+		m.Value = f
+	}
+
+	if m.Timestamp == 0 {
+		m.Timestamp = UnixMilli(time.Now())
+	}
+
+	mH := MetricHeader{
+		Id:   id,
+		Data: []Datapoint{m},
+		Type: Gauge,
+	}
+	return self.Write([]MetricHeader{mH})
+}
+
+// Read single Gauge metric's datapoints.
+// TODO: Remove and replace with better Read properties? Perhaps with iterators?
+func (self *Client) SingleGaugeMetric(id string, options map[string]string) ([]*Datapoint, error) {
+	id = self.cleanId(id)
+	url, err := self.paramUrl(self.dataUrl(self.singleMetricsUrl(Gauge, id)), options)
+
+	if err != nil {
+		return nil, err
+	}
+	b, err := self.get(url)
+	if err != nil {
+		return nil, err
+	}
+	metrics := []*Datapoint{}
+
+	if b != nil {
+		if err = json.Unmarshal(b, &metrics); err != nil {
+			return nil, err
+		}
+	}
+
+	return metrics, nil
+
+}
+
+// func (self *Client) QueryGaugesWithTags(id string, tags map[string]string) ([]MetricDefinition, error) {
+
+// Write using mixedmultimetrics
+// For now supports only single metricType per request
+func (self *Client) Write(metrics []MetricHeader) error {
+	if len(metrics) > 0 {
+		metricType := metrics[0].Type // Temp solution
+		if err := metricType.validate(); err != nil {
+			return err
+		}
+
+		jsonb, err := json.Marshal(&metrics)
+		if err != nil {
+			return err
+		}
+		return self.post(self.dataUrl(self.metricsUrl(metricType)), jsonb)
+	}
+	return nil
+}
+
+// HTTP Helper functions
+
+func (self *Client) get(url *url.URL) ([]byte, error) {
+	return self.send(url, "GET", nil)
+}
+
+func (self *Client) post(url *url.URL, json []byte) error {
+	_, err := self.send(url, "POST", json)
+	return err
+}
+
+func (self *Client) put(url *url.URL, json []byte) error {
+	_, err := self.send(url, "PUT", json)
+	return err
+}
+
+func (self *Client) del(url *url.URL) error {
+	_, err := self.send(url, "DELETE", nil)
+	return err
+}
+
+func (self *Client) cleanId(id string) string {
+	return url.QueryEscape(id)
+}
+
+// Override default http.NewRequest to avoid url.Parse which has a bug (removes valid %2F)
+func (self *Client) newRequest(url *url.URL, method string, body io.Reader) (*http.Request, error) {
+	rc, ok := body.(io.ReadCloser)
+	if !ok && body != nil {
+		rc = ioutil.NopCloser(body)
+	}
+
+	req := &http.Request{
+		Method:     method,
+		URL:        url,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+		Body:       rc,
+		Host:       url.Host,
+	}
+
+	if body != nil {
+		switch v := body.(type) {
+		case *bytes.Buffer:
+			req.ContentLength = int64(v.Len())
+		case *bytes.Reader:
+			req.ContentLength = int64(v.Len())
+		case *strings.Reader:
+			req.ContentLength = int64(v.Len())
+		}
+	}
+	return req, nil
+}
+
+func (self *Client) send(url *url.URL, method string, json []byte) ([]byte, error) {
+	// Have to replicate http.NewRequest here to avoid calling of url.Parse,
+	// which has a bug when it comes to encoded url
+	req, _ := self.newRequest(url, method, bytes.NewBuffer(json))
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Hawkular-Tenant", self.Tenant)
+	resp, err := self.client.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		b, err := ioutil.ReadAll(resp.Body)
+		return b, err
+	} else if resp.StatusCode > 399 {
+		return nil, self.parseErrorResponse(resp)
+	} else {
+		return nil, nil // Nothing to answer..
+	}
+}
+
+func (self *Client) parseErrorResponse(resp *http.Response) error {
+	// Parse error messages here correctly..
+	reply, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return &HawkularClientError{Code: resp.StatusCode,
+			msg: fmt.Sprintf("Reply could not be read: %s", err.Error()),
+		}
+	}
+
+	details := &HawkularError{}
+
+	err = json.Unmarshal(reply, details)
+	if err != nil {
+		return &HawkularClientError{Code: resp.StatusCode,
+			msg: fmt.Sprintf("Reply could not be parsed: %s", err.Error()),
+		}
+	}
+
+	return &HawkularClientError{Code: resp.StatusCode,
+		msg: details.ErrorMsg,
+	}
+}
+
+// URL functions (...)
+
+func (self *Client) metricsUrl(metricType MetricType) *url.URL {
+	mu := *self.url
+	self.addToUrl(&mu, metricType.String())
+	return &mu
+}
+
+func (self *Client) singleMetricsUrl(metricType MetricType, id string) *url.URL {
+	mu := self.metricsUrl(metricType)
+	self.addToUrl(mu, id)
+	return mu
+}
+
+func (self *Client) tagsUrl(mt MetricType, id string) *url.URL {
+	mu := self.singleMetricsUrl(mt, id)
+	self.addToUrl(mu, "tags")
+	return mu
+}
+
+func (self *Client) dataUrl(url *url.URL) *url.URL {
+	self.addToUrl(url, "data")
+	return url
+}
+
+func (self *Client) addToUrl(u *url.URL, s string) *url.URL {
+	u.Opaque = fmt.Sprintf("%s/%s", u.Opaque, s)
+	return u
+}
+
+func (self *Client) paramUrl(u *url.URL, options map[string]string) (*url.URL, error) {
+	q := u.Query()
+	for k, v := range options {
+		q.Set(k, v)
+	}
+
+	u.RawQuery = q.Encode()
+	return u, nil
+}

--- a/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/client_test.go
+++ b/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/client_test.go
@@ -1,0 +1,227 @@
+package metrics
+
+import (
+	"crypto/rand"
+	"fmt"
+	assert "github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func integrationClient() (*Client, error) {
+	t, err := randomString()
+	if err != nil {
+		return nil, err
+	}
+	// p := Parameters{Tenant: t, Host: "localhost:8080", Path: "hawkular/metrics"}
+	p := Parameters{Tenant: t, Host: "localhost:8080"}
+	// p := Parameters{Tenant: t, Host: "209.132.178.218:18080"}
+	return NewHawkularClient(p)
+}
+
+func randomString() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%X", b[:]), nil
+}
+
+func createError(err error) {
+}
+
+func TestCreate(t *testing.T) {
+	c, err := integrationClient()
+	assert.Nil(t, err)
+
+	id := "test.metric.create.numeric.1"
+	md := MetricDefinition{Id: id, Type: Gauge}
+	ok, err := c.Create(md)
+	assert.Nil(t, err)
+	assert.True(t, ok, "MetricDefinition should have been created")
+
+	// Commented out, see HWKMETRICS-110
+	// mdd, err := c.Definition(Gauge, id)
+	// assert.Nil(t, err)
+	// assert.Equal(t, md.Id, mdd.Id)
+
+	// Try to recreate the same..
+	ok, err = c.Create(md)
+	assert.False(t, ok, "Should have received false when recreating them same metric")
+	assert.Nil(t, err)
+
+	// Use tags and dataRetention
+	tags := make(map[string]string)
+	tags["units"] = "bytes"
+	tags["env"] = "unittest"
+	md_tags := MetricDefinition{Id: "test.metric.create.numeric.2", Tags: tags, Type: Gauge}
+
+	ok, err = c.Create(md_tags)
+	assert.True(t, ok, "MetricDefinition should have been created")
+	assert.Nil(t, err)
+
+	md_reten := MetricDefinition{Id: "test/metric/create/availability/1", RetentionTime: 12, Type: Availability}
+	ok, err = c.Create(md_reten)
+	assert.True(t, ok, "MetricDefinition should have been created")
+	assert.Nil(t, err)
+
+	// Fetch all the previously created metrics and test equalities..
+	mdq, err := c.Definitions(Gauge)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(mdq), "Size of the returned gauge metrics does not match 2")
+
+	mdm := make(map[string]MetricDefinition)
+	for _, v := range mdq {
+		mdm[v.Id] = *v
+	}
+
+	assert.Equal(t, md.Id, mdm[id].Id)
+	assert.True(t, reflect.DeepEqual(tags, mdm["test.metric.create.numeric.2"].Tags))
+
+	mda, err := c.Definitions(Availability)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(mda))
+	assert.Equal(t, "test/metric/create/availability/1", mda[0].Id)
+	assert.Equal(t, 12, mda[0].RetentionTime)
+
+	if mda[0].Type != Availability {
+		t.FailNow()
+	}
+}
+
+func TestAddGaugeSingle(t *testing.T) {
+	c, err := integrationClient()
+	assert.Nil(t, err)
+
+	// With timestamp
+	m := Datapoint{Timestamp: time.Now().UnixNano() / 1e6, Value: 1.34}
+	err = c.PushSingleGaugeMetric("test/numeric/single/1", m)
+	assert.Nil(t, err)
+
+	// Without preset timestamp
+	m = Datapoint{Value: 2}
+	err = c.PushSingleGaugeMetric("test.numeric.single.2", m)
+	assert.Nil(t, err)
+
+	//  for both metrics and check that they're correctly filled
+	params := make(map[string]string)
+	metrics, err := c.SingleGaugeMetric("test/numeric/single/1", params)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(metrics), "Received different amount of datapoints than sent")
+
+	metrics, err = c.SingleGaugeMetric("test.numeric.single.2", params)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(metrics), "Received more datapoints than written")
+	assert.False(t, metrics[0].Timestamp < 1, "Timestamp was not correctly populated")
+}
+
+func TestTagsModification(t *testing.T) {
+	if c, err := integrationClient(); err == nil {
+		id := "test/tags/modify/1"
+		// Create metric without tags
+		md := MetricDefinition{Id: id, Type: Gauge}
+		ok, err := c.Create(md)
+		assert.Nil(t, err)
+		assert.True(t, ok, "MetricDefinition should have been created")
+
+		// Add tags
+		tags := make(map[string]string)
+		tags["ab"] = "ac"
+		tags["host"] = "test"
+		err = c.UpdateTags(Gauge, id, tags)
+		assert.Nil(t, err)
+
+		// Fetch metric tags - check for equality
+		md_tags, err := c.Tags(Gauge, id)
+		assert.Nil(t, err)
+
+		assert.True(t, reflect.DeepEqual(tags, *md_tags), "Tags did not match the updated ones")
+
+		// Delete some metric tags
+		err = c.DeleteTags(Gauge, id, tags)
+		assert.Nil(t, err)
+
+		// Fetch metric - check that tags were deleted
+		md_tags, err = c.Tags(Gauge, id)
+		assert.Nil(t, err)
+		assert.False(t, len(*md_tags) > 0, "Received deleted tags")
+	}
+}
+
+func TestTags(t *testing.T) {
+	if c, err := integrationClient(); err == nil {
+		tags := make(map[string]string)
+		tTag, err := randomString()
+		tags[tTag] = "testValue"
+
+		// Write with tags
+		m := Datapoint{Value: float64(0.01), Tags: tags}
+		err = c.PushSingleGaugeMetric("test.tags.numeric.1", m)
+		assert.NoError(t, err)
+
+		// Search metrics with tag
+
+		// 		    @GET
+		// @Path("/{tenantId}/numeric")
+		// @ApiOperation(value = "Find numeric metrics data by their tags.", response = Map.cla@ApiParam(value = "Tag list", required = true) @Param("tags") Tags tags
+
+		// Get metric definition tags
+		// @Path("/{tenantId}/metrics/numeric/{id}/tags")
+		// @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = Metric.class)
+
+		// Fetch a metric with values and check we still have tags
+	}
+}
+
+func TestAddMixedMulti(t *testing.T) {
+
+	// Modify to send both Availability as well as Gauge metrics at the same time
+	if c, err := integrationClient(); err == nil {
+
+		mone := Datapoint{Value: 1.45, Timestamp: UnixMilli(time.Now())}
+		hone := MetricHeader{
+			Id:   "test.multi.numeric.1",
+			Data: []Datapoint{mone},
+			Type: Gauge,
+		}
+
+		mtwo_1 := Datapoint{Value: 2, Timestamp: UnixMilli(time.Now())}
+
+		mtwo_2_t := UnixMilli(time.Now()) - 1e3
+
+		mtwo_2 := Datapoint{Value: float64(4.56), Timestamp: mtwo_2_t}
+		htwo := MetricHeader{
+			Id:   "test.multi.numeric.2",
+			Data: []Datapoint{mtwo_1, mtwo_2},
+			Type: Gauge,
+		}
+
+		h := []MetricHeader{hone, htwo}
+
+		err = c.Write(h)
+		assert.NoError(t, err)
+
+		var checkDatapoints = func(id string, expected int) []*Datapoint {
+			metric, err := c.SingleGaugeMetric(id, make(map[string]string))
+			assert.NoError(t, err)
+			assert.Equal(t, expected, len(metric), "Amount of datapoints does not match expected value")
+			return metric
+		}
+
+		checkDatapoints("test.multi.numeric.1", 1)
+		checkDatapoints("test.multi.numeric.2", 2)
+	} else {
+		t.Error(err)
+	}
+}
+
+func TestCheckErrors(t *testing.T) {
+	c, err := integrationClient()
+	assert.Nil(t, err)
+
+	err = c.PushSingleGaugeMetric("test.number.as.string", Datapoint{Value: "notFloat"})
+	assert.NotNil(t, err, "Invalid non-float value should not be accepted")
+	_, err = c.SingleGaugeMetric("test.not.existing", make(map[string]string))
+	assert.Nil(t, err, "Querying empty metric should not generate an error")
+}

--- a/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/helpers.go
+++ b/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/helpers.go
@@ -1,0 +1,50 @@
+package metrics
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+)
+
+func ConvertToFloat64(v interface{}) (float64, error) {
+	switch i := v.(type) {
+	case float64:
+		return float64(i), nil
+	case float32:
+		return float64(i), nil
+	case int64:
+		return float64(i), nil
+	case int32:
+		return float64(i), nil
+	case int16:
+		return float64(i), nil
+	case int8:
+		return float64(i), nil
+	case uint64:
+		return float64(i), nil
+	case uint32:
+		return float64(i), nil
+	case uint16:
+		return float64(i), nil
+	case uint8:
+		return float64(i), nil
+	case int:
+		return float64(i), nil
+	case uint:
+		return float64(i), nil
+	case string:
+		f, err := strconv.ParseFloat(i, 64)
+		if err != nil {
+			return math.NaN(), err
+		}
+		return f, err
+	default:
+		return math.NaN(), fmt.Errorf("Cannot convert %s to float64", i)
+	}
+}
+
+// Returns milliseconds since epoch
+func UnixMilli(t time.Time) int64 {
+	return t.UnixNano() / 1e6
+}

--- a/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/types.go
+++ b/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/types.go
@@ -1,0 +1,77 @@
+package metrics
+
+import (
+	"fmt"
+)
+
+// MetricType restrictions
+type MetricType int
+
+const (
+	Gauge = iota
+	Availability
+	Counter
+	Generic
+)
+
+var longForm = []string{
+	"gauges",
+	"availability",
+	"counter",
+	"metrics",
+}
+
+var shortForm = []string{
+	"gauge",
+	"availability",
+	"counter",
+	"metrics",
+}
+
+func (self MetricType) validate() error {
+	if int(self) > len(longForm) && int(self) > len(shortForm) {
+		return fmt.Errorf("Given MetricType value %d is not valid", self)
+	}
+	return nil
+}
+
+func (self MetricType) String() string {
+	if err := self.validate(); err != nil {
+		return "unknown"
+	}
+	return longForm[self]
+}
+
+func (self MetricType) shortForm() string {
+	if err := self.validate(); err != nil {
+		return "unknown"
+	}
+	return shortForm[self]
+}
+
+// Hawkular-Metrics external structs
+
+type MetricHeader struct {
+	Type MetricType  `json:"-"`
+	Id   string      `json:"id"`
+	Data []Datapoint `json:"data"`
+}
+
+// Value should be convertible to float64 for numeric values
+// Timestamp is milliseconds since epoch
+type Datapoint struct {
+	Timestamp int64             `json:"timestamp"`
+	Value     interface{}       `json:"value"`
+	Tags      map[string]string `json:"tags,omitempty"`
+}
+
+type HawkularError struct {
+	ErrorMsg string `json:"errorMsg"`
+}
+
+type MetricDefinition struct {
+	Type          MetricType        `json:"-"`
+	Id            string            `json:"id"`
+	Tags          map[string]string `json:"tags,omitempty"`
+	RetentionTime int               `json:"dataRetention,omitempty"`
+}

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -30,10 +30,10 @@ The following options are available:
 
 
 ### Google Cloud Monitoring
-This sink supports both monitoring metrics only.
+This sink supports monitoring metrics only.
 To use the InfluxDB sink add the following flag:
 ```
---sink=influxdb:gcm
+--sink=gcm
 ```
 
 *Note: This sink works only on a Google Compute Enginer VM as of now*
@@ -45,14 +45,23 @@ This sink does not export any options!
 This sink supports events only.
 To use the InfluxDB sink add the following flag:
 ```
---sink=influxdb:gcl
+--sink=gcl
 ```
 
 *Note: This sink works only on a Google Compute Enginer VM as of now*
 
 This sink does not export any options!
 
+### Hawkular-Metrics
+This sink supports monitoring metrics only.
+To use the Hawkular-Metrics sink add the following flag:
 
+```
+--sink=hawkular:<HAWKULAR_SERVER_URL>[?<OPTIONS>]
+```
 
+If `HAWKULAR_SERVER_URL` includes any path, the default `hawkular/metrics` is overridden.
 
+The following options are available:
 
+* `tenant` - Hawkular-Metrics tenantId (default: `heapster`)

--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -74,3 +74,16 @@ Metrics mentioned above are stored along with corresponding labels as [custom me
 
 TODO: Add a snapshot of all the metrics stored in GCM.
 
+### Hawkular
+
+Each metric is stored as separate timeseries (metric) in Hawkular-Metrics with tags being inherited from common ancestor type. The metric name is created with the following format: `containerName/podId/metricName` (`/` is separator). All the metrics are stored as gauges at this point (this might change after the counter type has been redefined in the Hawkular). Each definition stores the labels as tags with following addons:
+
+* All the Label descriptions are stored as label_description
+* The ancestor metric name (such as cpu/usage) is stored under the tag `descriptor_name`
+* To ease search, a tag with `group_id` stores the key `containerName/metricName` so each podId can be linked under a single timeseries if necessary.
+* Type (Gauge / Cumulative) is stored to `type` tag
+* Units are stored under `units` tag
+
+At the start, all the definitions are fetched from the Hawkular-Metrics tenant and filtered to cache only the Heapster metrics. It is recommended to use a separate tenant for Heapster information if you have lots of metrics from other systems, but not required.
+
+The Hawkular-Metrics instance can be a standalone installation of Hawkular-Metrics or the full installation of Hawkular. 

--- a/sinks/hawkular/driver.go
+++ b/sinks/hawkular/driver.go
@@ -1,0 +1,284 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hawkular
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/heapster/extpoints"
+	"github.com/golang/glog"
+	"github.com/hawkular/hawkular-client-go/metrics"
+
+	sink_api "github.com/GoogleCloudPlatform/heapster/sinks/api"
+	kube_api "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+const (
+	unitsTag       string = "units"
+	typeTag        string = "type"
+	descriptionTag string = "_description"
+	descriptorTag  string = "descriptor_name"
+	groupTag       string = "group_id"
+	separator      string = "/"
+)
+
+type hawkularSink struct {
+	client  *metrics.Client
+	models  map[string]metrics.MetricDefinition // Model definitions
+	regLock sync.Mutex
+	reg     map[string]*metrics.MetricDefinition // Real definitions
+}
+
+// START: ExternalSink interface implementations
+
+func (self *hawkularSink) Register(mds []sink_api.MetricDescriptor) error {
+	self.regLock.Lock()
+	defer self.regLock.Unlock()
+
+	// Create model definitions based on the MetricDescriptors
+	for _, md := range mds {
+		hmd := self.descriptorToDefinition(&md)
+		self.models[md.Name] = hmd
+	}
+
+	// Fetch currently known metrics from Hawkular-Metrics and cache them
+	prev, err := self.client.Definitions(metrics.Gauge)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range prev {
+		// If no descriptorTag is found, this metric does not belong to Heapster
+		if mk, found := p.Tags[descriptorTag]; found {
+			model := self.models[mk]
+			if !self.recent(p, &model) {
+				if err := self.client.UpdateTags(metrics.Gauge, p.Id, p.Tags); err != nil {
+					return err
+				}
+			}
+			self.reg[p.Id] = p
+		}
+	}
+
+	return nil
+}
+
+// Checks that stored definition is up to date with the model
+func (self *hawkularSink) recent(live *metrics.MetricDefinition, model *metrics.MetricDefinition) bool {
+	recent := true
+	for k, _ := range model.Tags {
+		if v, found := live.Tags[k]; !found {
+			// There's a label that wasn't in our stored definition
+			live.Tags[k] = v
+			recent = false
+		}
+	}
+
+	return recent
+}
+
+// Transform the MetricDescriptor to a format used by Hawkular-Metrics
+func (self *hawkularSink) descriptorToDefinition(md *sink_api.MetricDescriptor) metrics.MetricDefinition {
+	tags := make(map[string]string)
+	// Postfix description tags with _description
+	for _, l := range md.Labels {
+		if len(l.Description) > 0 {
+			tags[l.Key+descriptionTag] = l.Description
+		}
+	}
+
+	if len(md.Units.String()) > 0 {
+		tags[unitsTag] = md.Units.String()
+	}
+	if len(md.Type.String()) > 0 {
+		tags[typeTag] = md.Type.String()
+	}
+
+	tags[descriptorTag] = md.Name
+
+	hmd := metrics.MetricDefinition{
+		Id:   md.Name,
+		Tags: tags,
+	}
+
+	return hmd
+}
+
+func (self *hawkularSink) groupName(p *sink_api.Point) string {
+	n := []string{p.Labels[sink_api.LabelContainerName], p.Name}
+	return strings.Join(n, separator)
+}
+
+func (self *hawkularSink) idName(p *sink_api.Point) string {
+	n := []string{p.Labels[sink_api.LabelContainerName], p.Labels[sink_api.LabelPodId], p.Name}
+	return strings.Join(n, separator)
+}
+
+// Check that metrics tags are defined on the Hawkular server and if not,
+// register the metric definition.
+func (self *hawkularSink) registerIfNecessary(t *sink_api.Timeseries) error {
+	key := self.idName(t.Point)
+
+	self.regLock.Lock()
+	defer self.regLock.Unlock()
+
+	// If found, check it matches the current stored definition (could be old info from
+	// the stored metrics cache for example)
+	if _, found := self.reg[key]; !found {
+		// Register the metric descriptor here..
+		if md, f := self.models[t.MetricDescriptor.Name]; f {
+			// Set tag values
+			for k, v := range t.Point.Labels {
+				md.Tags[k] = v
+			}
+
+			md.Tags[groupTag] = self.groupName(t.Point)
+			md.Tags[descriptorTag] = t.MetricDescriptor.Name
+
+			// Create metric, use updateTags instead of Create because we know it is unique
+			if err := self.client.UpdateTags(metrics.Gauge, key, md.Tags); err != nil {
+				// Log error and don't add this key to the lookup table
+				glog.Errorf("Could not update tags: %s", err)
+				return err
+			}
+
+			// Add to the lookup table
+			self.reg[key] = &md
+			glog.Infof("Registered new metric definition: %s", key)
+		} else {
+			return fmt.Errorf("Could not find definition model with name %s", t.MetricDescriptor.Name)
+		}
+	}
+	// TODO Compare the definition tags and update if necessary? Quite expensive operation..
+
+	return nil
+}
+
+func (self *hawkularSink) StoreTimeseries(ts []sink_api.Timeseries) error {
+	if len(ts) > 0 {
+		mhs := make([]metrics.MetricHeader, 0, len(ts))
+
+		for _, t := range ts {
+			self.registerIfNecessary(&t)
+
+			if t.MetricDescriptor.ValueType == sink_api.ValueBool {
+				// TODO: Model to availability type once we see some real world examples
+				break
+			}
+
+			mH, err := self.pointToMetricHeader(&t)
+			if err != nil {
+				// One transformation error should not prevent the whole process
+				glog.Errorf(err.Error())
+				continue
+			}
+
+			mhs = append(mhs, *mH)
+		}
+
+		return self.client.Write(mhs)
+	}
+	return nil
+}
+
+// Converts Timeseries to metric structure used by the Hawkular
+func (self *hawkularSink) pointToMetricHeader(t *sink_api.Timeseries) (*metrics.MetricHeader, error) {
+
+	p := t.Point
+	name := self.idName(p)
+
+	value, err := metrics.ConvertToFloat64(p.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	m := metrics.Datapoint{
+		Value:     value,
+		Timestamp: metrics.UnixMilli(p.End),
+	}
+
+	// At the moment all the values are converted to gauges.
+	mh := &metrics.MetricHeader{
+		Id:   name,
+		Data: []metrics.Datapoint{m},
+		Type: metrics.Gauge,
+	}
+	return mh, nil
+}
+
+func (self *hawkularSink) DebugInfo() string {
+	info := fmt.Sprintf("Hawkular-Metrics Sink\n")
+
+	self.regLock.Lock()
+	defer self.regLock.Unlock()
+	info += fmt.Sprintf("Known metrics: %d", len(self.reg))
+
+	// TODO Add here statistics from the Hawkular-Metrics client instance
+	return info
+}
+
+func (self *hawkularSink) StoreEvents(events []kube_api.Event) error {
+	// TODO: Delegate to Fabric8 event storage (if available) until Hawkular has a solution?
+	return nil
+}
+
+func (self *hawkularSink) Name() string {
+	return "Hawkular-Metrics sink"
+}
+
+// END: ExternalSink
+
+func init() {
+	extpoints.SinkFactories.Register(NewHawkularSink, "hawkular")
+}
+
+func NewHawkularSink(uri string, options map[string][]string) ([]sink_api.ExternalSink, error) {
+
+	parsedUrl, err := url.Parse(os.ExpandEnv(uri))
+	if err != nil {
+		return nil, err
+	}
+
+	p := metrics.Parameters{
+		Tenant: "heapster",
+		Host:   parsedUrl.Host,
+	}
+
+	// Connection parameters
+	if len(parsedUrl.Path) > 0 {
+		p.Path = parsedUrl.Path
+	}
+
+	if v, found := options["tenant"]; found {
+		p.Tenant = v[0]
+	}
+
+	c, err := metrics.NewHawkularClient(p)
+	if err != nil {
+		return nil, err
+	}
+	glog.Infof("Created Hawkular Sink with parameters %v", p)
+
+	hSink := &hawkularSink{client: c,
+		reg:    make(map[string]*metrics.MetricDefinition),
+		models: make(map[string]metrics.MetricDefinition),
+	}
+
+	return []sink_api.ExternalSink{hSink}, nil
+}

--- a/sinks/hawkular/driver_test.go
+++ b/sinks/hawkular/driver_test.go
@@ -1,0 +1,128 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hawkular
+
+import (
+	"fmt"
+	"github.com/GoogleCloudPlatform/heapster/sinks/api"
+	"github.com/hawkular/hawkular-client-go/metrics"
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func dummySink() *hawkularSink {
+	return &hawkularSink{
+		reg:    make(map[string]*metrics.MetricDefinition),
+		models: make(map[string]metrics.MetricDefinition),
+	}
+}
+
+func TestDescriptorTransform(t *testing.T) {
+
+	hSink := dummySink()
+
+	ld := api.LabelDescriptor{
+		Key:         "k1",
+		Description: "d1",
+	}
+	smd := api.MetricDescriptor{
+		Name:      "test/metric/1",
+		Units:     api.UnitsBytes,
+		ValueType: api.ValueInt64,
+		Type:      api.MetricGauge,
+		Labels:    []api.LabelDescriptor{ld},
+	}
+
+	md := hSink.descriptorToDefinition(&smd)
+
+	assert.Equal(t, smd.Name, md.Id)
+	assert.Equal(t, 4, len(md.Tags)) // descriptorTag, unitsTag, typesTag, k1
+
+	assert.Equal(t, smd.Units.String(), md.Tags[unitsTag])
+	assert.Equal(t, "d1", md.Tags["k1_description"])
+}
+
+func TestMetricTransform(t *testing.T) {
+	hSink := dummySink()
+
+	smd := api.MetricDescriptor{
+		ValueType: api.ValueInt64,
+		Type:      api.MetricCumulative,
+	}
+
+	l := make(map[string]string)
+	l["spooky"] = "notvisible"
+	l[api.LabelHostname] = "localhost"
+	l[api.LabelContainerName] = "docker"
+	l[api.LabelPodId] = "aaaa-bbbb-cccc-dddd"
+
+	p := api.Point{
+		Name:   "test/metric/1",
+		Labels: l,
+		Start:  time.Now(),
+		End:    time.Now(),
+		Value:  int64(123456),
+	}
+
+	ts := api.Timeseries{
+		MetricDescriptor: &smd,
+		Point:            &p,
+	}
+
+	m, err := hSink.pointToMetricHeader(&ts)
+	assert.NoError(t, err)
+
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", p.Labels[api.LabelContainerName], p.Labels[api.LabelPodId], p.Name), m.Id)
+
+	assert.Equal(t, 1, len(m.Data))
+	_, ok := m.Data[0].Value.(float64)
+	assert.True(t, ok, "Value should have been converted to float64")
+}
+
+func TestRecentTest(t *testing.T) {
+	hSink := dummySink()
+
+	modelT := make(map[string]string)
+
+	id := "test.name"
+	modelT[descriptorTag] = "d"
+	modelT[groupTag] = id
+	modelT["hep"+descriptionTag] = "n"
+
+	model := metrics.MetricDefinition{
+		Id:   id,
+		Tags: modelT,
+	}
+
+	liveT := make(map[string]string)
+	for k, v := range modelT {
+		liveT[k] = v
+	}
+
+	live := metrics.MetricDefinition{
+		Id:   "test/" + id,
+		Tags: liveT,
+	}
+
+	assert.True(t, hSink.recent(&live, &model), "Tags are equal, live is newest")
+
+	delete(liveT, "hep"+descriptionTag)
+	live.Tags = liveT
+
+	assert.False(t, hSink.recent(&live, &model), "Tags are not equal, live isn't recent")
+
+}

--- a/sinks/modules.go
+++ b/sinks/modules.go
@@ -17,5 +17,6 @@ package sinks
 import (
 	_ "github.com/GoogleCloudPlatform/heapster/sinks/gcl"
 	_ "github.com/GoogleCloudPlatform/heapster/sinks/gcm"
+	_ "github.com/GoogleCloudPlatform/heapster/sinks/hawkular"
 	_ "github.com/GoogleCloudPlatform/heapster/sinks/influxdb"
 )


### PR DESCRIPTION
This PR provides support for pushing numerical metrics to the Hawkular-Metrics (http://www.hawkular.org/) for monitoring purposes. The Hawkular-Metrics endpoints can be used standalone or with a full Hawkular 

github.com/hawkular/hawkular-client-go/metrics is a required dependency.