### PR TITLE
Fixed URL in influxdb kube-config and updated readme

### DIFF
--- a/deploy/kube-config/influxdb/influxdb-grafana-controller.json
+++ b/deploy/kube-config/influxdb/influxdb-grafana-controller.json
@@ -38,7 +38,7 @@
             "env": [
               {
                 "name": "INFLUXDB_EXTERNAL_URL",
-                "value": "/api/v1beta1/proxy/services/monitoring-grafana/db/"
+                "value": "/api/v1beta3/proxy/namespaces/default/services/monitoring-grafana/db/"
               },
               {
                 "name": "INFLUXDB_HOST",

--- a/docs/influxdb.md
+++ b/docs/influxdb.md
@@ -10,7 +10,7 @@ _Warning: Virtual machines need to have at least 2 cores for InfluxDB to perform
 $ kubectl.sh create -f deploy/kube-config/influxdb/
 ```
 
-Grafana will be accessible at `https://<masterIP>/api/v1beta3/proxy/services/monitoring-grafana/`. Use the master auth to access Grafana.
+Grafana will be accessible at `https://<masterIP>/api/v1beta3/proxy/namespaces/default/services/monitoring-grafana/`. Use the master auth to access Grafana.
 
 ## Production setup for InfluxDB and Grafana
 


### PR DESCRIPTION
I noticed that the kubectl deploy for influxdb did not work - the external and internal URL and version of API was incorrect.