### PR TITLE
corrected typos and phrasing of error messages

### DIFF
--- a/sources/datasource/kubelet.go
+++ b/sources/datasource/kubelet.go
@@ -165,7 +165,7 @@ func (self *kubeletSource) getAllContainers(url string, start, end time.Time, re
 	var containers map[string]cadvisor.ContainerInfo
 	err = self.postRequestAndGetValue(http.DefaultClient, req, &containers)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get all container stats from Kubeler URL %q: %v", url, err)
+		return nil, fmt.Errorf("failed to get all container stats from Kubelet URL %q: %v", url, err)
 	}
 
 	// TODO(vmarmol): Use this for all stats gathering.

--- a/sources/kube_nodes.go
+++ b/sources/kube_nodes.go
@@ -44,8 +44,8 @@ func (self *kubeNodeMetrics) updateStats(host nodes.Host, info nodes.Info, start
 	// Get information for all containers.
 	containers, err := self.kubeletApi.GetAllRawContainers(datasource.Host{IP: info.InternalIP, Port: self.kubeletPort}, start, end, resolution)
 	if err != nil {
-		glog.V(3).Infof("Failed to get container stats from kubelet for node %q", host)
-		return nil, []api.Container{}, fmt.Errorf("failed to get container stats from Kubeler node %q: %v", host, err)
+		glog.V(3).Infof("Failed to get container stats from Kubelet on node %q", host)
+		return nil, []api.Container{}, fmt.Errorf("failed to get container stats from Kubelet on node %q: %v", host, err)
 	}
 	if len(containers) == 0 {
 		// no stats found.


### PR DESCRIPTION
Just spotted some typos in a few error messages related to Kubelet sources