### PR TITLE
Removed go vet dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ all: build
 deps:
 	go get github.com/tools/godep
 	go get github.com/progrium/go-extpoints
-	go get golang.org/x/tools/cmd/vet
 
 build: clean deps
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go generate github.com/GoogleCloudPlatform/heapster


### PR DESCRIPTION
Vet is now part of the golang distribution, through the go.tools subdirectory. 
Therefore, the dependency should be satisfied by the go distribution itself, rather than go get.