### PR TITLE
Additional node metrics for autoscaling.

### DIFF
--- a/sinks/api/decoder_test.go
+++ b/sinks/api/decoder_test.go
@@ -69,8 +69,11 @@ func getContainer(name string) source_api.Container {
 	containerStats := make([]*cadvisor.ContainerStats, 1)
 	f.Fuzz(&containerStats)
 	return source_api.Container{
-		Name:  name,
-		Spec:  containerSpec,
+		Name: name,
+		Spec: source_api.ContainerSpec{
+			ContainerSpec: containerSpec,
+			HasResourceId: true,
+		},
 		Stats: containerStats,
 	}
 }
@@ -214,8 +217,16 @@ func TestRealInput(t *testing.T) {
 				name, ok := entry.Point.Labels[LabelResourceID]
 				require.True(t, ok)
 				assert.Equal(t, expectedFsStats[name].limit, value)
+			case "cpu/node_usage":
+				value, ok := entry.Point.Value.(int64)
+				require.True(t, ok)
+				assert.Equal(t, stats.Cpu.Usage.Total, value)
+			case "memory/node_usage":
+				value, ok := entry.Point.Value.(int64)
+				require.True(t, ok)
+				assert.Equal(t, stats.Memory.Usage, value)
 			default:
-				t.Errorf("unexpected metric type")
+				t.Errorf("unexpected metric type %s", entry.Point.Name)
 			}
 		}
 	}

--- a/sinks/api/decoder_test.go
+++ b/sinks/api/decoder_test.go
@@ -72,7 +72,7 @@ func getContainer(name string) source_api.Container {
 		Name: name,
 		Spec: source_api.ContainerSpec{
 			ContainerSpec: containerSpec,
-			HasResourceId: true,
+			IsNode:        true,
 		},
 		Stats: containerStats,
 	}

--- a/sinks/api/decoder_v2_test.go
+++ b/sinks/api/decoder_v2_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/heapster/sinks/cache"
+	source_api "github.com/GoogleCloudPlatform/heapster/sources/api"
 	cadvisor_api "github.com/google/cadvisor/info/v1"
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +45,7 @@ func TestFuzzInputV2(t *testing.T) {
 
 func getContainerElement(name string) *cache.ContainerElement {
 	f := fuzz.New().NumElements(1, 1).NilChance(0)
-	containerSpec := &cadvisor_api.ContainerSpec{
+	containerSpec := cadvisor_api.ContainerSpec{
 		CreationTime:  time.Unix(fakeContainerCreationTime, 0),
 		HasCpu:        true,
 		HasMemory:     true,
@@ -66,7 +67,10 @@ func getContainerElement(name string) *cache.ContainerElement {
 		},
 		Metrics: []*cache.ContainerMetricElement{
 			{
-				Spec:  containerSpec,
+				Spec: &source_api.ContainerSpec{
+					ContainerSpec: containerSpec,
+					HasResourceId: true,
+				},
 				Stats: containerStats[0],
 			},
 		},
@@ -197,8 +201,16 @@ func TestRealInputV2(t *testing.T) {
 				name, ok := entry.Point.Labels[LabelResourceID]
 				require.True(t, ok)
 				assert.Equal(t, expectedFsStats[name].limit, value)
+			case "cpu/node_usage":
+				value, ok := entry.Point.Value.(int64)
+				require.True(t, ok)
+				assert.Equal(t, stats.Cpu.Usage.Total, value)
+			case "memory/node_usage":
+				value, ok := entry.Point.Value.(int64)
+				require.True(t, ok)
+				assert.Equal(t, stats.Memory.Usage, value)
 			default:
-				t.Errorf("unexpected metric type")
+				t.Errorf("unexpected metric type %s", entry.Point.Name)
 			}
 		}
 	}

--- a/sinks/api/decoder_v2_test.go
+++ b/sinks/api/decoder_v2_test.go
@@ -69,7 +69,7 @@ func getContainerElement(name string) *cache.ContainerElement {
 			{
 				Spec: &source_api.ContainerSpec{
 					ContainerSpec: containerSpec,
-					HasResourceId: true,
+					IsNode:        true,
 				},
 				Stats: containerStats[0],
 			},

--- a/sinks/api/supported_labels.go
+++ b/sinks/api/supported_labels.go
@@ -15,14 +15,16 @@
 package api
 
 const (
-	LabelPodId           = "pod_id"
-	LabelPodName         = "pod_name"
-	LabelPodNamespace    = "pod_namespace"
-	LabelPodNamespaceUID = "namespace_id"
-	LabelContainerName   = "container_name"
-	LabelLabels          = "labels"
-	LabelHostname        = "hostname"
-	LabelResourceID      = "resource_id"
+	LabelPodId               = "pod_id"
+	LabelPodName             = "pod_name"
+	LabelPodNamespace        = "pod_namespace"
+	LabelPodNamespaceUID     = "namespace_id"
+	LabelContainerName       = "container_name"
+	LabelLabels              = "labels"
+	LabelHostname            = "hostname"
+	LabelResourceID          = "resource_id"
+	LabelComputeResourceID   = "compute.googleapis.com/resource_id"
+	LabelComputeResourceType = "compute.googleapis.com/resource_type"
 )
 
 // TODO(vmarmol): Things we should consider adding (note that we only get 10 labels):
@@ -60,6 +62,14 @@ var allLabels = []LabelDescriptor{
 	{
 		Key:         LabelResourceID,
 		Description: "Identifier(s) specific to a metric",
+	},
+	{
+		Key:         LabelComputeResourceID,
+		Description: "Resource id for machines (GCE, used for auto-scaling)",
+	},
+	{
+		Key:         LabelComputeResourceType,
+		Description: "Resource type for machines (GCE, used for auto-scaling)",
 	},
 }
 

--- a/sinks/api/supported_metrics.go
+++ b/sinks/api/supported_metrics.go
@@ -17,6 +17,7 @@ package api
 import (
 	"time"
 
+	source_api "github.com/GoogleCloudPlatform/heapster/sources/api"
 	cadvisor "github.com/google/cadvisor/info/v1"
 )
 
@@ -32,10 +33,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsMilliseconds,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return !spec.CreationTime.IsZero()
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			return []internalPoint{{value: timeSince(spec.CreationTime).Nanoseconds() / time.Millisecond.Nanoseconds()}}
 		},
 	},
@@ -47,10 +48,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsNanoseconds,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasCpu
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			return []internalPoint{{value: int64(stat.Cpu.Usage.Total)}}
 		},
 	},
@@ -62,10 +63,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsCount,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasCpu && (spec.Cpu.Limit > 0)
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			// Normalize to a conversion factor of 1000.
 			return []internalPoint{{value: int64(spec.Cpu.Limit*1000) / 1024}}
 		},
@@ -79,10 +80,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsBytes,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasMemory
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			return []internalPoint{{value: int64(stat.Memory.Usage)}}
 		},
 	},
@@ -94,10 +95,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsBytes,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasMemory
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			return []internalPoint{{value: int64(stat.Memory.WorkingSet)}}
 		},
 	},
@@ -109,10 +110,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsBytes,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasMemory && (spec.Memory.Limit > 0)
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			return []internalPoint{{value: int64(spec.Memory.Limit)}}
 		},
 		OnlyExportIfChanged: true,
@@ -125,10 +126,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsCount,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasMemory
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			return []internalPoint{{value: int64(stat.Memory.ContainerData.Pgfault)}}
 		},
 	},
@@ -140,10 +141,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsCount,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasMemory
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			return []internalPoint{{value: int64(stat.Memory.ContainerData.Pgmajfault)}}
 		},
 	},
@@ -155,10 +156,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsBytes,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasNetwork
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			return []internalPoint{{value: int64(stat.Network.RxBytes)}}
 		},
 	},
@@ -170,10 +171,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsCount,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasNetwork
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			return []internalPoint{{value: int64(stat.Network.RxErrors)}}
 		},
 	},
@@ -185,10 +186,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsBytes,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasNetwork
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			return []internalPoint{{value: int64(stat.Network.TxBytes)}}
 		},
 	},
@@ -200,10 +201,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsCount,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasNetwork
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			return []internalPoint{{value: int64(stat.Network.TxErrors)}}
 		},
 	},
@@ -215,10 +216,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsBytes,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasFilesystem
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			result := make([]internalPoint, 0, len(stat.Filesystem))
 			for _, fs := range stat.Filesystem {
 				result = append(result, internalPoint{
@@ -239,10 +240,10 @@ var statMetrics = []SupportedStatMetric{
 			ValueType:   ValueInt64,
 			Units:       UnitsBytes,
 		},
-		HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		HasValue: func(spec *source_api.ContainerSpec) bool {
 			return spec.HasFilesystem
 		},
-		GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			result := make([]internalPoint, 0, len(stat.Filesystem))
 			for _, fs := range stat.Filesystem {
 				result = append(result, internalPoint{
@@ -256,7 +257,50 @@ var statMetrics = []SupportedStatMetric{
 		},
 		OnlyExportIfChanged: true,
 	},
-
+	{
+		MetricDescriptor: MetricDescriptor{
+			Name:        "cpu/node_usage",
+			Description: "Cumulative CPU usage on all cores on a node",
+			Type:        MetricCumulative,
+			ValueType:   ValueInt64,
+			Units:       UnitsNanoseconds,
+		},
+		HasValue: func(spec *source_api.ContainerSpec) bool {
+			return spec.HasCpu && spec.HasResourceId
+		},
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			result := internalPoint{
+				value: int64(stat.Cpu.Usage.Total),
+				labels: map[string]string{
+					LabelComputeResourceID:   spec.ResourceId,
+					LabelComputeResourceType: "instance",
+				},
+			}
+			return []internalPoint{result}
+		},
+	},
+	{
+		MetricDescriptor: MetricDescriptor{
+			Name:        "memory/node_usage",
+			Description: "Total memory usage on a node",
+			Type:        MetricGauge,
+			ValueType:   ValueInt64,
+			Units:       UnitsBytes,
+		},
+		HasValue: func(spec *source_api.ContainerSpec) bool {
+			return spec.HasMemory && spec.HasResourceId
+		},
+		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
+			result := internalPoint{
+				value: int64(stat.Memory.Usage),
+				labels: map[string]string{
+					LabelComputeResourceID:   spec.ResourceId,
+					LabelComputeResourceType: "instance",
+				},
+			}
+			return []internalPoint{result}
+		},
+	},
 	// TODO(vmarmol): DiskIO stats if we find those useful and know how to export them in a user-friendly way.
 }
 

--- a/sinks/api/supported_metrics.go
+++ b/sinks/api/supported_metrics.go
@@ -266,13 +266,13 @@ var statMetrics = []SupportedStatMetric{
 			Units:       UnitsNanoseconds,
 		},
 		HasValue: func(spec *source_api.ContainerSpec) bool {
-			return spec.HasCpu && spec.HasResourceId
+			return spec.HasCpu && spec.IsNode
 		},
 		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			result := internalPoint{
 				value: int64(stat.Cpu.Usage.Total),
 				labels: map[string]string{
-					LabelComputeResourceID:   spec.ResourceId,
+					LabelComputeResourceID:   spec.ExternalID,
 					LabelComputeResourceType: "instance",
 				},
 			}
@@ -288,13 +288,13 @@ var statMetrics = []SupportedStatMetric{
 			Units:       UnitsBytes,
 		},
 		HasValue: func(spec *source_api.ContainerSpec) bool {
-			return spec.HasMemory && spec.HasResourceId
+			return spec.HasMemory && spec.IsNode
 		},
 		GetValue: func(spec *source_api.ContainerSpec, stat *cadvisor.ContainerStats) []internalPoint {
 			result := internalPoint{
 				value: int64(stat.Memory.Usage),
 				labels: map[string]string{
-					LabelComputeResourceID:   spec.ResourceId,
+					LabelComputeResourceID:   spec.ExternalID,
 					LabelComputeResourceType: "instance",
 				},
 			}

--- a/sinks/api/types.go
+++ b/sinks/api/types.go
@@ -17,6 +17,7 @@ package api
 import (
 	"time"
 
+	source_api "github.com/GoogleCloudPlatform/heapster/sources/api"
 	cadvisor "github.com/google/cadvisor/info/v1"
 )
 
@@ -145,10 +146,10 @@ type SupportedStatMetric struct {
 	MetricDescriptor
 
 	// Returns whether this metric is present.
-	HasValue func(*cadvisor.ContainerSpec) bool
+	HasValue func(*source_api.ContainerSpec) bool
 
 	// Returns a slice of internal point objects that contain metric values and associated labels.
-	GetValue func(*cadvisor.ContainerSpec, *cadvisor.ContainerStats) []internalPoint
+	GetValue func(*source_api.ContainerSpec, *cadvisor.ContainerStats) []internalPoint
 
 	// TODO(vmarmol): Make use of this.
 	// Whether to only export if the metric's value has changed (Default: false).

--- a/sinks/bigquery.go
+++ b/sinks/bigquery.go
@@ -173,7 +173,7 @@ func (self *bigquerySink) containerStatsToValues(
 	pod *api.Pod,
 	hostname,
 	containerName string,
-	spec cadvisor.ContainerSpec,
+	spec api.ContainerSpec,
 	stat *cadvisor.ContainerStats) (row map[string]interface{}) {
 	row = make(map[string]interface{})
 

--- a/sinks/cache/cache.go
+++ b/sinks/cache/cache.go
@@ -31,7 +31,7 @@ type Metadata struct {
 }
 
 type ContainerMetricElement struct {
-	Spec  *cadvisor_api.ContainerSpec
+	Spec  *source_api.ContainerSpec
 	Stats *cadvisor_api.ContainerStats
 }
 

--- a/sinks/cache/cache_impl_test.go
+++ b/sinks/cache/cache_impl_test.go
@@ -59,7 +59,7 @@ func getContainer(name string) source_api.Container {
 	}
 	return source_api.Container{
 		Name:  name,
-		Spec:  containerSpec,
+		Spec:  source_api.ContainerSpec{ContainerSpec: containerSpec},
 		Stats: containerStats,
 	}
 }

--- a/sinks/gcm/driver.go
+++ b/sinks/gcm/driver.go
@@ -416,7 +416,7 @@ const (
 )
 
 func fullLabelName(name string) string {
-	if !strings.Contains(name, "custom.cloudmonitoring.googleapis.com/") {
+	if !strings.Contains(name, "googleapis.com/") {
 		return fmt.Sprintf("custom.cloudmonitoring.googleapis.com/%s/label/%s", metricDomain, name)
 	}
 	return name

--- a/sinks/gcm/rate_metrics.go
+++ b/sinks/gcm/rate_metrics.go
@@ -49,4 +49,8 @@ var gcmRateMetrics = map[string]rateMetric{
 		name:        "network/tx_errors_rate",
 		description: "Rate of errors transmitting over the network in errors per second",
 	},
+	"cpu/node_usage": rateMetric{
+		name:        "cpu/node_usage_rate",
+		description: "Rate of total CPU usage in millicores per second for a node",
+	},
 }

--- a/sources/api/types.go
+++ b/sources/api/types.go
@@ -56,12 +56,17 @@ func (a *AggregateData) Merge(b *AggregateData) {
 	a.Events = append(a.Events, b.Events...)
 }
 
+type ContainerSpec struct {
+	cadvisor.ContainerSpec
+	HasResourceId bool
+	ResourceId    string
+}
+
 type Container struct {
 	Hostname string
 	Name     string
-	// TODO(vishh): Consider defining an internal Spec and Stats API to guard against
-	// changes to cadvisor API.
-	Spec  cadvisor.ContainerSpec
+	Spec     ContainerSpec
+	// TODO(vishh): Consider defining an internal Stats API to guard against changes to cadvisor API.
 	Stats []*cadvisor.ContainerStats
 }
 

--- a/sources/api/types.go
+++ b/sources/api/types.go
@@ -58,8 +58,8 @@ func (a *AggregateData) Merge(b *AggregateData) {
 
 type ContainerSpec struct {
 	cadvisor.ContainerSpec
-	HasResourceId bool
-	ResourceId    string
+	IsNode     bool
+	ExternalID string
 }
 
 type Container struct {

--- a/sources/datasource/cadvisor.go
+++ b/sources/datasource/cadvisor.go
@@ -32,7 +32,7 @@ type cadvisorSource struct{}
 func (self *cadvisorSource) parseStat(containerInfo *cadvisor.ContainerInfo, resolution time.Duration) *api.Container {
 	container := &api.Container{
 		Name:  containerInfo.Name,
-		Spec:  containerInfo.Spec,
+		Spec:  api.ContainerSpec{ContainerSpec: containerInfo.Spec},
 		Stats: sampleContainerStats(containerInfo.Stats, resolution),
 	}
 	if len(containerInfo.Aliases) > 0 {

--- a/sources/datasource/cadvisor_test.go
+++ b/sources/datasource/cadvisor_test.go
@@ -52,11 +52,11 @@ func TestBasicCadvisor(t *testing.T) {
 func TestDetailedCadvisor(t *testing.T) {
 	rootContainer := api.Container{
 		Name: "/",
-		Spec: cadvisor_api.ContainerSpec{
+		Spec: api.ContainerSpec{ContainerSpec: cadvisor_api.ContainerSpec{
 			CreationTime: time.Now(),
 			HasCpu:       true,
 			HasMemory:    true,
-		},
+		}},
 		Stats: []*cadvisor_api.ContainerStats{
 			{
 				Timestamp: time.Now(),
@@ -66,11 +66,11 @@ func TestDetailedCadvisor(t *testing.T) {
 	subContainers := []api.Container{
 		{
 			Name: "a",
-			Spec: cadvisor_api.ContainerSpec{
+			Spec: api.ContainerSpec{ContainerSpec: cadvisor_api.ContainerSpec{
 				CreationTime: time.Now(),
 				HasCpu:       true,
 				HasMemory:    true,
-			},
+			}},
 			Stats: []*cadvisor_api.ContainerStats{
 				{
 					Timestamp: time.Now(),
@@ -79,11 +79,11 @@ func TestDetailedCadvisor(t *testing.T) {
 		},
 		{
 			Name: "b",
-			Spec: cadvisor_api.ContainerSpec{
+			Spec: api.ContainerSpec{ContainerSpec: cadvisor_api.ContainerSpec{
 				CreationTime: time.Now(),
 				HasCpu:       true,
 				HasMemory:    true,
-			},
+			}},
 			Stats: []*cadvisor_api.ContainerStats{
 				{
 					Timestamp: time.Now(),
@@ -97,7 +97,7 @@ func TestDetailedCadvisor(t *testing.T) {
 			ContainerReference: cadvisor_api.ContainerReference{
 				Name: rootContainer.Name,
 			},
-			Spec:  rootContainer.Spec,
+			Spec:  rootContainer.Spec.ContainerSpec,
 			Stats: rootContainer.Stats,
 		},
 	}
@@ -106,7 +106,7 @@ func TestDetailedCadvisor(t *testing.T) {
 			ContainerReference: cadvisor_api.ContainerReference{
 				Name: cont.Name,
 			},
-			Spec:  cont.Spec,
+			Spec:  cont.Spec.ContainerSpec,
 			Stats: cont.Stats,
 		})
 	}
@@ -127,12 +127,12 @@ func TestDetailedCadvisor(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, subcontainers, len(subContainers))
 	assert.NotNil(t, root)
-	assert.True(t, root.Spec.Eq(&rootContainer.Spec))
+	assert.True(t, root.Spec.Eq(&rootContainer.Spec.ContainerSpec))
 	for i, stat := range root.Stats {
 		assert.True(t, stat.Eq(rootContainer.Stats[i]))
 	}
 	for i, cont := range subcontainers {
-		assert.True(t, subContainers[i].Spec.Eq(&cont.Spec))
+		assert.True(t, subContainers[i].Spec.Eq(&cont.Spec.ContainerSpec))
 		for j, stat := range cont.Stats {
 			assert.True(t, subContainers[i].Stats[j].Eq(stat))
 		}

--- a/sources/datasource/kubelet.go
+++ b/sources/datasource/kubelet.go
@@ -65,7 +65,7 @@ func (self *kubeletSource) parseStat(containerInfo *cadvisor.ContainerInfo, reso
 	}
 	container := &api.Container{
 		Name:  containerInfo.Name,
-		Spec:  containerInfo.Spec,
+		Spec:  api.ContainerSpec{ContainerSpec: containerInfo.Spec},
 		Stats: sampleContainerStats(containerInfo.Stats, resolution),
 	}
 	if len(containerInfo.Aliases) > 0 {

--- a/sources/datasource/kubelet_test.go
+++ b/sources/datasource/kubelet_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func checkContainer(t *testing.T, expected api.Container, actual api.Container) {
-	assert.True(t, actual.Spec.Eq(&expected.Spec))
+	assert.True(t, actual.Spec.ContainerSpec.Eq(&expected.Spec.ContainerSpec))
 	for i, stat := range actual.Stats {
 		assert.True(t, stat.Eq(expected.Stats[i]))
 	}
@@ -55,11 +55,11 @@ func TestBasicKubelet(t *testing.T) {
 func TestDetailedKubelet(t *testing.T) {
 	rootContainer := api.Container{
 		Name: "/",
-		Spec: cadvisor_api.ContainerSpec{
+		Spec: api.ContainerSpec{ContainerSpec: cadvisor_api.ContainerSpec{
 			CreationTime: time.Now(),
 			HasCpu:       true,
 			HasMemory:    true,
-		},
+		}},
 		Stats: []*cadvisor_api.ContainerStats{
 			{
 				Timestamp: time.Now(),
@@ -70,7 +70,7 @@ func TestDetailedKubelet(t *testing.T) {
 		ContainerReference: cadvisor_api.ContainerReference{
 			Name: rootContainer.Name,
 		},
-		Spec:  rootContainer.Spec,
+		Spec:  rootContainer.Spec.ContainerSpec,
 		Stats: rootContainer.Stats,
 	}
 	data, err := json.Marshal(&response)
@@ -92,11 +92,11 @@ func TestDetailedKubelet(t *testing.T) {
 func TestAllContainers(t *testing.T) {
 	rootContainer := api.Container{
 		Name: "/",
-		Spec: cadvisor_api.ContainerSpec{
+		Spec: api.ContainerSpec{ContainerSpec: cadvisor_api.ContainerSpec{
 			CreationTime: time.Now(),
 			HasCpu:       true,
 			HasMemory:    true,
-		},
+		}},
 		Stats: []*cadvisor_api.ContainerStats{
 			{
 				Timestamp: time.Now(),
@@ -105,11 +105,11 @@ func TestAllContainers(t *testing.T) {
 	}
 	subcontainer := api.Container{
 		Name: "/sub",
-		Spec: cadvisor_api.ContainerSpec{
+		Spec: api.ContainerSpec{ContainerSpec: cadvisor_api.ContainerSpec{
 			CreationTime: time.Now(),
 			HasCpu:       true,
 			HasMemory:    true,
-		},
+		}},
 		Stats: []*cadvisor_api.ContainerStats{
 			{
 				Timestamp: time.Now(),
@@ -121,14 +121,14 @@ func TestAllContainers(t *testing.T) {
 			ContainerReference: cadvisor_api.ContainerReference{
 				Name: rootContainer.Name,
 			},
-			Spec:  rootContainer.Spec,
+			Spec:  rootContainer.Spec.ContainerSpec,
 			Stats: rootContainer.Stats,
 		},
 		subcontainer.Name: {
 			ContainerReference: cadvisor_api.ContainerReference{
 				Name: subcontainer.Name,
 			},
-			Spec:  subcontainer.Spec,
+			Spec:  subcontainer.Spec.ContainerSpec,
 			Stats: subcontainer.Stats,
 		},
 	}

--- a/sources/kube_nodes.go
+++ b/sources/kube_nodes.go
@@ -59,10 +59,8 @@ func (self *kubeNodeMetrics) updateStats(host nodes.Host, info nodes.Info, start
 	for i := range containers {
 		if containers[i].Name == "/" {
 			hostIndex = i
-			if len(info.ResourceId) > 0 {
-				containers[i].Spec.HasResourceId = true
-				containers[i].Spec.ResourceId = info.ResourceId
-			}
+			containers[i].Spec.IsNode = true
+			containers[i].Spec.ExternalID = info.ExternalID
 		}
 		containers[i].Hostname = hostString
 	}

--- a/sources/kube_nodes.go
+++ b/sources/kube_nodes.go
@@ -59,6 +59,10 @@ func (self *kubeNodeMetrics) updateStats(host nodes.Host, info nodes.Info, start
 	for i := range containers {
 		if containers[i].Name == "/" {
 			hostIndex = i
+			if len(info.ResourceId) > 0 {
+				containers[i].Spec.HasResourceId = true
+				containers[i].Spec.ResourceId = info.ResourceId
+			}
 		}
 		containers[i].Hostname = hostString
 	}

--- a/sources/nodes/coreos_test.go
+++ b/sources/nodes/coreos_test.go
@@ -63,8 +63,8 @@ func TestSuccessCase(t *testing.T) {
 	nodeList, err := nodesApi.List()
 	require.NoError(t, err)
 	assert.Len(t, nodeList.Items, 2)
-	assert.Equal(t, nodeList.Items["a"], Info{"1.2.3.4", "1.2.3.4"})
-	assert.Equal(t, nodeList.Items["b"], Info{"1.2.3.5", "1.2.3.5"})
+	assert.Equal(t, nodeList.Items["a"], Info{"1.2.3.4", "1.2.3.4", ""})
+	assert.Equal(t, nodeList.Items["b"], Info{"1.2.3.5", "1.2.3.5", ""})
 }
 
 func TestFailureCase(t *testing.T) {

--- a/sources/nodes/kube.go
+++ b/sources/nodes/kube.go
@@ -89,6 +89,7 @@ func (self *kubeNodes) getNodeInfoAndHostname(node api.Node) (Info, string, erro
 			}
 		}
 	}
+	nodeInfo.ResourceId = node.Spec.ExternalID
 	return nodeInfo, hostname, nodeErr
 }
 

--- a/sources/nodes/kube.go
+++ b/sources/nodes/kube.go
@@ -89,7 +89,7 @@ func (self *kubeNodes) getNodeInfoAndHostname(node api.Node) (Info, string, erro
 			}
 		}
 	}
-	nodeInfo.ResourceId = node.Spec.ExternalID
+	nodeInfo.ExternalID = node.Spec.ExternalID
 	return nodeInfo, hostname, nodeErr
 }
 

--- a/sources/nodes/types.go
+++ b/sources/nodes/types.go
@@ -29,7 +29,7 @@ type Info struct {
 	// restricted behind firewalls.
 	InternalIP string `json:"internal_ip,omitempty"`
 	// External ID of the node (e.g. assigned by a cloud provider)
-	ResourceId string
+	ExternalID string
 }
 
 // NodeList contains the nodes that an instance of heapster is required to

--- a/sources/nodes/types.go
+++ b/sources/nodes/types.go
@@ -28,6 +28,8 @@ type Info struct {
 	// use to communicate with the host sinc Public IP access is usually
 	// restricted behind firewalls.
 	InternalIP string `json:"internal_ip,omitempty"`
+	// External ID of the node (e.g. assigned by a cloud provider)
+	ResourceId string
 }
 
 // NodeList contains the nodes that an instance of heapster is required to


### PR DESCRIPTION
Added additional node metrics (tracking cpu and mem usage) together with additional lables. They are in format compatible with cloud autoscaler, and they can be used to autoscale the numer of nodes in a cluster.