### PR TITLE
(WIP) Basic skeleton for metric data structure

### DIFF
--- a/api/repr/api.go
+++ b/api/repr/api.go
@@ -1,0 +1,70 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repr
+
+import (
+	"encoding/json"
+	"github.com/emicklei/go-restful"
+	"github.com/golang/glog"
+	"net/http"
+)
+
+type ReprApi struct {
+	cluster Cluster
+}
+
+// Create a new Api to serve from the specified cluster.
+func NewReprApi(c Cluster) *ReprApi {
+	return &ReprApi{
+		cluster: c,
+	}
+}
+
+// Register the Api on the appropriate endpoints.
+func (a *ReprApi) Register(container *restful.Container) {
+	ws := new(restful.WebService)
+	ws.
+		Path("/api/repr/cluster").
+		Doc("Exports all metrics at the cluster level").
+		Produces(restful.MIME_JSON)
+	ws.Route(ws.GET("").
+		Filter(compressionFilter).
+		To(a.exportAllClusterMetrics).
+		Doc("Exports all metrics at the cluster level").
+		Operation("allCluster").
+		Writes(ClusterInfo{}))
+
+	container.Add(ws)
+}
+
+func (a *ReprApi) exportAllClusterMetrics(request *restful.Request, response *restful.Response) {
+	clinfo, _, err := a.cluster.GetAllClusterData()
+
+	glog.Infof("Exported All Cluster Metrics")
+
+	response.WriteAsJson(clinfo)
+}
+
+func compressionFilter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	// wrap responseWriter into a compressing one
+	compress, err := restful.NewCompressingResponseWriter(resp.ResponseWriter, restful.ENCODING_GZIP)
+	if err != nil {
+		glog.Warningf("Failed to create CompressingResponseWriter for request %q: %v", req.Request.URL, err)
+		return
+	}
+	resp.ResponseWriter = compress
+	defer compress.Close()
+	chain.ProcessFilter(req, resp)
+}

--- a/api/repr/impl.go
+++ b/api/repr/impl.go
@@ -1,0 +1,117 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repr
+
+import (
+	"github.com/GoogleCloudPlatform/heapster/sinks/cache"
+	"github.com/golang/glog"
+	"time"
+)
+
+func NewCluster() Cluster {
+	var zero time.Time
+	namespaces := make(map[string]*NamespaceInfo)
+	nodes := make(map[string]*NodeInfo)
+	cinfo := ClusterInfo{newInfoType(nil, nil), namespaces, nodes}
+	cluster := &realCluster{zero, cinfo}
+	return cluster
+}
+
+func (rc *realCluster) GetAllClusterData() (*ClusterInfo, time.Time, error) {
+	/* Returns the entire ClusterInfo object */
+	return &rc.ClusterInfo, time.Now(), nil
+}
+
+func (rc *realCluster) Update(c cache.Cache) error {
+	/*
+	 *	Get new data from cache and update data structure
+	 */
+	var zero time.Time
+
+	// Invoke cache interface since the last timestamp
+	nodes := c.GetNodes(rc.timestamp, zero)
+	latest_time := rc.timestamp
+
+	for _, node := range nodes {
+		timestamp := rc.updateNode(node)
+		latest_time = maxTimestamp(latest_time, timestamp)
+	}
+
+	pods := c.GetPods(rc.timestamp, zero)
+	for _, pod := range pods {
+		rc.updatePod(pod)
+	}
+
+	free_containers := c.GetFreeContainers(rc.timestamp, zero)
+	for _, container := range free_containers {
+		rc.updateContainer(container)
+	}
+
+	// Update the Cluster timestamp to the latest time found in the Update sequence
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	rc.timestamp = latest_time
+
+	return nil
+}
+
+func (rc *realCluster) updateNode(node_container *cache.ContainerElement) time.Time {
+	/*	Inserts or updates Node information from the
+	 *	"machine"-tagged containers
+	 */
+	container_name := node_container.Name
+	if container_name != "machine" {
+		glog.Fatalf("Received node-level container with unexpected name")
+	}
+
+	node_name := node_container.Hostname
+
+	if _, ok := rc.Nodes[node_name]; !ok {
+		// Node name does not exist, create a new NodeInfo object
+		rc.addNode(node_name)
+	}
+
+	// Update NodeInfo's Metrics and Labels - return latest metric timestamp
+	return updateInfoType(&rc.Nodes[node_name].InfoType, node_container)
+}
+
+func (rc *realCluster) addNode(hostname string) *NodeInfo {
+	/*	Creates a new NodeInfo object for the provided hostname
+	 */
+
+	// Allocate all new structures
+	pods := make(map[string]*PodInfo)
+	free_conts := make(map[string]*ContainerInfo)
+	new_node := NodeInfo{newInfoType(nil, nil), pods, free_conts}
+
+	// Obtain Cluster Lock and point to new_node
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	rc.Nodes[hostname] = &new_node
+
+	return &new_node
+}
+
+func (rc *realCluster) updatePod(pod *cache.PodElement) {
+	/*	Inserts or updates Pod information from
+	 *	pod-labelled containers
+	 */
+}
+
+func (rc *realCluster) updateContainer(container *cache.ContainerElement) {
+	/*	Inserts or updates Container information from
+	 *	a single container element
+	 */
+}

--- a/api/repr/types.go
+++ b/api/repr/types.go
@@ -1,0 +1,78 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repr
+
+import (
+	"github.com/GoogleCloudPlatform/heapster/sinks/cache"
+	"sync"
+	"time"
+)
+
+type Cluster interface {
+	Update(cache.Cache) error
+
+	GetAllClusterData() (*ClusterInfo, time.Time, error)
+	/*
+		GetNewClusterData(time.Time) (*ClusterInfo, time.Time, error)
+
+		GetAllNodeData(string) (*NodeInfo, time.Time, error)
+		GetNewNodeData(string, time.Time) (*NodeInfo, time.Time, error)
+
+		GetAllPodData(string) (*PodInfo, time.Time, error)
+		GetNewPodData(string) (*PodInfo, time.Time, error)
+	*/
+}
+
+type realCluster struct {
+	timestamp time.Time // Cluster timestamp signifies the last update from cache.
+	ClusterInfo
+}
+
+type InfoType struct {
+	Metrics map[string][]*MetricTimeseries
+	Labels  map[string]string
+	lock    *sync.RWMutex
+}
+
+type ClusterInfo struct {
+	InfoType
+	Namespaces map[string]*NamespaceInfo
+	Nodes      map[string]*NodeInfo
+}
+
+type NamespaceInfo struct {
+	InfoType
+	Pods map[string]*PodInfo
+}
+
+type NodeInfo struct {
+	InfoType
+	Pods           map[string]*PodInfo
+	FreeContainers map[string]*ContainerInfo
+}
+
+type PodInfo struct {
+	InfoType
+	Containers map[string]*ContainerInfo
+}
+
+type ContainerInfo struct {
+	InfoType
+}
+
+type MetricTimeseries struct {
+	Timestamp time.Time
+	Value     uint64
+}

--- a/api/repr/util.go
+++ b/api/repr/util.go
@@ -1,0 +1,140 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repr
+
+import (
+	"github.com/GoogleCloudPlatform/heapster/sinks/cache"
+	"sync"
+	"time"
+)
+
+func maxTimestamp(first time.Time, second time.Time) time.Time {
+	if first.After(second) {
+		return first
+	} else {
+		return second
+	}
+}
+
+func updateInfoType(info *InfoType, ce *cache.ContainerElement) time.Time {
+	/* Updates the metrics of an InfoType struct from a ContainerElement struct
+	*  Returns the max timestamp in the resulting timeseries slice
+	 */
+	new_metrics := parseMetrics(ce.Metrics)
+
+	var latest_time time.Time
+
+	// Update Metrics
+	for key, metricSlice := range new_metrics {
+		if val, ok := info.Metrics[key]; ok {
+			// Metric already exists in info, merge timeseries slices
+			info.Metrics[key] = append(val, metricSlice...)
+		} else {
+			// New Metric to add to info
+			info.Metrics[key] = metricSlice
+		}
+
+		if val, ok := info.Metrics[key]; ok {
+			// Calculate new latest timestamp
+			for _, metric := range val {
+				latest_time = maxTimestamp(latest_time, metric.Timestamp)
+			}
+		}
+	}
+	/* TODO: manage length of historical data */
+
+	// Copy labels from the ContainerElement to InfoType
+	info.Labels = ce.Labels
+
+	return latest_time
+}
+
+func newInfoType(metrics map[string][]*MetricTimeseries, labels map[string]string) InfoType {
+	/* InfoType Constructor */
+	if metrics == nil {
+		metrics = make(map[string][]*MetricTimeseries)
+	}
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	return InfoType{metrics, labels, new(sync.RWMutex)}
+}
+
+func addMetricToMap(metric string, timestamp time.Time, value uint64, dict_ref *map[string][]*MetricTimeseries) error {
+	/*
+	*	Adds a metric to a map of MetricTimeseries
+	 */
+	dict := *dict_ref
+	if val, ok := dict[metric]; ok {
+		dict[metric] = append(val, &MetricTimeseries{timestamp, value})
+	} else {
+		new_timeseries := &MetricTimeseries{timestamp, value}
+		dict[metric] = []*MetricTimeseries{new_timeseries}
+	}
+	return nil
+}
+
+func parseMetrics(cmes []*cache.ContainerMetricElement) map[string][]*MetricTimeseries {
+	/*
+	*	Generates a map of MetricTimeseries slices from a slice of ContainerMetricElements
+	 */
+	metrics := make(map[string][]*MetricTimeseries)
+
+	for _, cme := range cmes {
+		timestamp := cme.Stats.Timestamp
+		if cme.Spec.HasCpu {
+			// Add CPU limit
+			cpu_limit := cme.Spec.Cpu.Limit
+			if cpu_limit > 0 {
+				addMetricToMap("cpu/limit", timestamp, cpu_limit, &metrics)
+			}
+
+			// Add CPU metric
+			cpu_usage := cme.Stats.Cpu.Usage.Total
+			addMetricToMap("cpu/usage", timestamp, cpu_usage, &metrics)
+		}
+
+		if cme.Spec.HasMemory {
+			// Add Memory Limit metric
+			mem_limit := cme.Spec.Memory.Limit
+			if mem_limit > 0 {
+				// TODO: -1 values from cache?
+				addMetricToMap("memory/limit", timestamp, mem_limit, &metrics)
+			}
+
+			// Add Memory Usage metric
+			mem_usage := cme.Stats.Memory.Usage
+			addMetricToMap("memory/usage", timestamp, mem_usage, &metrics)
+
+			// Add Memory Working Set metric
+			mem_working := cme.Stats.Memory.Usage
+			addMetricToMap("memory/working", timestamp, mem_working, &metrics)
+		}
+		if cme.Spec.HasFilesystem {
+			for _, fsstat := range cme.Stats.Filesystem {
+				dev := fsstat.Device
+
+				/* Add FS limit, if applicable */
+				fs_limit := fsstat.Limit
+				addMetricToMap("fs/limit"+dev, timestamp, fs_limit, &metrics)
+
+				/* Add FS metric */
+				fs_usage := fsstat.Usage
+				addMetricToMap("fs/usage"+dev, timestamp, fs_usage, &metrics)
+			}
+		}
+	}
+	return metrics
+}

--- a/handlers.go
+++ b/handlers.go
@@ -20,6 +20,7 @@ import (
 	"net/http/pprof"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/heapster/api/repr"
 	"github.com/GoogleCloudPlatform/heapster/api/v1"
 	"github.com/GoogleCloudPlatform/heapster/manager"
 	"github.com/GoogleCloudPlatform/heapster/sinks"
@@ -35,6 +36,10 @@ func setupHandlers(sources []api.Source, sink sinks.ExternalSinkManager, m manag
 	wsContainer := restful.NewContainer()
 	a := v1.NewApi(m)
 	a.Register(wsContainer)
+
+	// Make ReprApi handler.
+	reprApi := repr.NewReprApi(m.GetCluster())
+	reprApi.Register(wsContainer)
 
 	// Validation/Debug handler.
 	handleValidate := func(req *restful.Request, resp *restful.Response) {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/heapster/api/repr"
 	"github.com/GoogleCloudPlatform/heapster/sinks"
 	sink_api "github.com/GoogleCloudPlatform/heapster/sinks/api"
 	"github.com/GoogleCloudPlatform/heapster/sinks/cache"
@@ -35,11 +36,14 @@ type Manager interface {
 
 	// Export the latest data point of all metrics.
 	ExportMetrics() ([]*sink_api.Point, error)
+
+	GetCluster() repr.Cluster
 }
 
 type realManager struct {
 	sources     []source_api.Source
 	cache       cache.Cache
+	cluster     repr.Cluster
 	sinkManager sinks.ExternalSinkManager
 	lastSync    time.Time
 	resolution  time.Duration
@@ -56,6 +60,7 @@ func NewManager(sources []source_api.Source, sinkManager sinks.ExternalSinkManag
 		sources:     sources,
 		sinkManager: sinkManager,
 		cache:       cache.NewCache(bufferDuration),
+		cluster:     repr.NewCluster(),
 		lastSync:    time.Now(),
 		resolution:  res,
 		decoder:     sink_api.NewV2Decoder(),
@@ -73,6 +78,10 @@ func (rm *realManager) scrapeSource(s source_api.Source, start, end time.Time, s
 		sd.data.Merge(&data)
 	}
 	errChan <- err
+}
+
+func (rm *realManager) GetCluster() repr.Cluster {
+	return rm.cluster
 }
 
 func (rm *realManager) Housekeep() {
@@ -108,6 +117,8 @@ func (rm *realManager) Housekeep() {
 	if len(errors) > 0 {
 		glog.V(1).Infof("housekeeping resulted in following errors: %v", errors)
 	}
+
+	rm.cluster.Update(rm.cache)
 }
 
 func (rm *realManager) ExportMetrics() ([]*sink_api.Point, error) {


### PR DESCRIPTION
I'm creating a data structure that consumes metrics from the cache and organizes them in a fashion that can be easily consumed by REST endpoints.

At the current state, only node metrics are processed and exposed, without any aggregation over cluster metrics.

File structure:
types.go - contains the interface and types of the data structure
impl.go - contains all methods of the RealCluster Implementation
util.go - contains helper functions that will be reused extensively by the implementation

Next steps: 
- unit tests and error handling for all functions on util.go
- implement updateContainer & addContainer 
- implement updatePod & addPod
- Implement GetNode, GetPod and GetContainer

Temporary concerns:
- Update will not be invoked during housekeeping (discussion pending)