### PR TITLE
Move TimeStore definition and implementations outside of cache module

### DIFF
--- a/schema/types.go
+++ b/schema/types.go
@@ -16,6 +16,7 @@ package schema
 
 import (
 	"github.com/GoogleCloudPlatform/heapster/sinks/cache"
+	"github.com/GoogleCloudPlatform/heapster/store"
 	"sync"
 	"time"
 )
@@ -41,7 +42,7 @@ type realCluster struct {
 // REST consumption requires conversion to the corresponding versioned API types
 
 type InfoType struct {
-	Metrics map[string]*cache.TimeStore // key: Metric Name
+	Metrics map[string]*store.TimeStore // key: Metric Name
 	Labels  map[string]string           // key: Label
 }
 

--- a/sinks/cache/cache_impl.go
+++ b/sinks/cache/cache_impl.go
@@ -19,11 +19,12 @@ import (
 	"time"
 
 	source_api "github.com/GoogleCloudPlatform/heapster/sources/api"
+	"github.com/GoogleCloudPlatform/heapster/store"
 )
 
 type containerElement struct {
 	Metadata
-	metrics TimeStore
+	metrics store.TimeStore
 }
 
 type podElement struct {
@@ -54,7 +55,7 @@ const rootContainer = "/"
 
 func (rc *realCache) newContainerElement() *containerElement {
 	return &containerElement{
-		metrics: NewGCStore(NewTimeStore(), rc.bufferDuration),
+		metrics: store.NewGCStore(store.NewTimeStore(), rc.bufferDuration),
 	}
 }
 

--- a/store/gc_store.go
+++ b/store/gc_store.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cache
+package store
 
 import (
 	"time"

--- a/store/gc_store_test.go
+++ b/store/gc_store_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cache
+package store
 
 import (
 	"testing"

--- a/store/in_memory.go
+++ b/store/in_memory.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cache
+package store
 
 import (
 	"container/list"

--- a/store/in_memory_test.go
+++ b/store/in_memory_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cache
+package store
 
 import (
 	"testing"

--- a/store/time_store.go
+++ b/store/time_store.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package cache implements a cache for time series data.
-package cache
+package store
 
 import "time"
 


### PR DESCRIPTION
This PR moves the definition and implementations of TimeStores outside of the cache package, along with related references. 

Sidenote: There might be confusion between store.gcStore and utils.gcstore.GCStore