### PR TITLE
[Schema 3] Adders and Unit Tests

### DIFF
--- a/schema/impl.go
+++ b/schema/impl.go
@@ -167,7 +167,7 @@ func (rc *realCluster) addPod(pod_name string, pod_uid string, namespace *Namesp
 	if in_ns && in_node {
 		// Pod already in Namespace and Node maps, return pointer
 		pod_ptr, _ = node.Pods[pod_name]
-	} else if !in_ns && !in_node {
+	} else {
 		// Create new Pod and point from node and namespace
 		pod_ptr = &PodInfo{
 			InfoType:   newInfoType(nil, nil),

--- a/schema/impl.go
+++ b/schema/impl.go
@@ -16,13 +16,10 @@ package schema
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/GoogleCloudPlatform/heapster/sinks/cache"
 )
-
-var lock sync.RWMutex
 
 func NewCluster() Cluster {
 	return newRealCluster()
@@ -41,19 +38,23 @@ func newRealCluster() *realCluster {
 	return cluster
 }
 
+// GetAllClusterData returns a pointer to the ClusterInfo, along with all of its metrics.
+// GetAllClusterData also returns the latest cluster timestamp, for reuse in GetNew* methods.
 func (rc *realCluster) GetAllClusterData() (*ClusterInfo, time.Time, error) {
-	// Returns the entire ClusterInfo object
-	lock.RLock()
-	defer lock.RUnlock()
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
 	return &rc.ClusterInfo, rc.timestamp, nil
 }
 
+// GetAllNodeData finds a node, given a hostname (internal to the cluster).
+// GetAllNodeData returns a corresponding NodeInfo object, along with all of its metrics.
+// GetAllNodeData also returns the latest cluster timestamp, for reuse in GetNew* methods.
 func (rc *realCluster) GetAllNodeData(hostname string) (*NodeInfo, time.Time, error) {
-	// Returns the corresponding NodeInfo object
+	// TODO(alex): should return a deep copy instead of a pointer
 	var zeroTime time.Time
 
-	lock.RLock()
-	defer lock.RUnlock()
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
 
 	res, ok := rc.Nodes[hostname]
 	if !ok {
@@ -63,12 +64,15 @@ func (rc *realCluster) GetAllNodeData(hostname string) (*NodeInfo, time.Time, er
 	return res, rc.timestamp, nil
 }
 
+// GetAllPodData finds a pod, given a namespace string and a pod name string.
+// GetAllPodData returns a pointer to a PodInfo object, along with all of its metrics.
+// GetAllPodData also returns the latest cluster timestamp, for reuse in GetNew* methods.
 func (rc *realCluster) GetAllPodData(namespace string, pod_name string) (*PodInfo, time.Time, error) {
-	// Returns the corresponding NodeInfo object
+	// TODO(alex): should return a deep copy instead of a pointer
 	var zeroTime time.Time
 
-	lock.RLock()
-	defer lock.RUnlock()
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
 
 	if len(rc.Namespaces) == 0 {
 		return nil, zeroTime, fmt.Errorf("unable to find pod: no namespaces in cluster")
@@ -90,4 +94,89 @@ func (rc *realCluster) GetAllPodData(namespace string, pod_name string) (*PodInf
 func (rc *realCluster) Update(c *cache.Cache) error {
 	// TODO(afein): Unimplemented
 	return nil
+}
+
+// updateTime updates the Cluster timestamp to the specified time.
+func (rc *realCluster) updateTime(new_time time.Time) {
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	rc.timestamp = new_time
+}
+
+// addNode creates or finds a NodeInfo element for the provided (internal) hostname.
+// addNode returns a pointer to the NodeInfo element that was created or found.
+// addNode assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) addNode(hostname string) *NodeInfo {
+	var node_ptr *NodeInfo
+
+	if val, ok := rc.Nodes[hostname]; ok {
+		// Node element already exists, return pointer
+		node_ptr = val
+	} else {
+		// Node does not exist in map, create a new NodeInfo object
+		node_ptr = &NodeInfo{
+			InfoType:       newInfoType(nil, nil),
+			Pods:           make(map[string]*PodInfo),
+			FreeContainers: make(map[string]*ContainerInfo),
+		}
+
+		// Add Pointer to new_node under cluster.Nodes
+		rc.Nodes[hostname] = node_ptr
+	}
+	return node_ptr
+}
+
+// addNamespace creates or finds a NamespaceInfo element for the provided namespace.
+// addNamespace returns a pointer to the NamespaceInfo element that was created or found.
+// addNamespace assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) addNamespace(name string) *NamespaceInfo {
+	var namespace_ptr *NamespaceInfo
+
+	if val, ok := rc.Namespaces[name]; ok {
+		// Namespace already exists, return pointer
+		namespace_ptr = val
+	} else {
+		// Namespace does not exist in map, create a new NamespaceInfo struct
+		namespace_ptr = &NamespaceInfo{
+			InfoType: newInfoType(nil, nil),
+			Pods:     make(map[string]*PodInfo),
+		}
+		rc.Namespaces[name] = namespace_ptr
+	}
+
+	return namespace_ptr
+}
+
+// addPod creates or finds a PodInfo element under the provided NodeInfo and NamespaceInfo.
+// addPod returns a pointer to the PodInfo element that was created or found.
+// addPod assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) addPod(pod_name string, pod_uid string, namespace *NamespaceInfo, node *NodeInfo) *PodInfo {
+	var pod_ptr *PodInfo
+	var in_ns bool
+	var in_node bool
+
+	// Check if the pod is already referenced by the namespace or the node
+	if _, ok := namespace.Pods[pod_name]; ok {
+		in_ns = true
+	}
+
+	if _, ok := node.Pods[pod_name]; ok {
+		in_node = true
+	}
+
+	if in_ns && in_node {
+		// Pod already in Namespace and Node maps, return pointer
+		pod_ptr, _ = node.Pods[pod_name]
+	} else if !in_ns && !in_node {
+		// Create new Pod and point from node and namespace
+		pod_ptr = &PodInfo{
+			InfoType:   newInfoType(nil, nil),
+			UID:        pod_uid,
+			Containers: make(map[string]*ContainerInfo),
+		}
+		namespace.Pods[pod_name] = pod_ptr
+		node.Pods[pod_name] = pod_ptr
+	}
+
+	return pod_ptr
 }

--- a/schema/impl_test.go
+++ b/schema/impl_test.go
@@ -86,11 +86,6 @@ func TestAddPod(t *testing.T) {
 	new_pod := cluster.addPod(pod_name, pod_uid, namespace, node)
 	assert.NotNil(new_pod)
 	assert.Equal(new_pod, pod)
-
-	// Third call : References are mismatched
-	other_node := cluster.addNode("other-kubernetes-minion")
-	newest_pod := cluster.addPod(pod_name, pod_uid, namespace, other_node)
-	assert.Nil(newest_pod)
 }
 
 // TestUpdateTime tests the sanity of updateTime.

--- a/schema/impl_test.go
+++ b/schema/impl_test.go
@@ -1,0 +1,104 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAddNamespace tests all flows of addNamespace.
+func TestAddNamespace(t *testing.T) {
+	cluster := newRealCluster()
+	namespace_name := "default"
+
+	// First call : namespace does not exist
+	namespace := cluster.addNamespace(namespace_name)
+
+	assert := assert.New(t)
+	assert.NotNil(namespace)
+	assert.Equal(cluster.Namespaces[namespace_name], namespace)
+	assert.NotNil(namespace.Metrics)
+	assert.NotNil(namespace.Labels)
+	assert.NotNil(namespace.Pods)
+
+	// Second call : namespace already exists
+	new_namespace := cluster.addNamespace(namespace_name)
+	assert.Equal(new_namespace, namespace)
+}
+
+// TestAddNode tests all flows of addNode.
+func TestAddNode(t *testing.T) {
+	cluster := newRealCluster()
+	hostname := "kubernetes-minion-xkhz"
+
+	// First call : node does not exist
+	node := cluster.addNode(hostname)
+
+	assert := assert.New(t)
+	assert.NotNil(node)
+	assert.Equal(cluster.Nodes[hostname], node)
+	assert.NotNil(node.Metrics)
+	assert.NotNil(node.Labels)
+	assert.NotNil(node.FreeContainers)
+	assert.NotNil(node.Pods)
+
+	// Second call : node already exists
+	new_node := cluster.addNode(hostname)
+	assert.Equal(new_node, node)
+}
+
+// TestAddPod tests all flows of addPod.
+func TestAddPod(t *testing.T) {
+	cluster := newRealCluster()
+	pod_name := "podname-xkhz"
+	pod_uid := "123124-124124-124124124124"
+	namespace := cluster.addNamespace("default")
+	node := cluster.addNode("kubernetes-minion-xkhz")
+
+	// First call : pod does not exist
+	pod := cluster.addPod(pod_name, pod_uid, namespace, node)
+
+	assert := assert.New(t)
+	assert.NotNil(pod)
+	assert.Equal(node.Pods[pod_name], pod)
+	assert.Equal(namespace.Pods[pod_name], pod)
+	assert.Equal(pod.UID, pod_uid)
+	assert.NotNil(pod.Metrics)
+	assert.NotNil(pod.Labels)
+	assert.NotNil(pod.Containers)
+
+	// Second call : pod already exists
+	new_pod := cluster.addPod(pod_name, pod_uid, namespace, node)
+	assert.NotNil(new_pod)
+	assert.Equal(new_pod, pod)
+
+	// Third call : References are mismatched
+	other_node := cluster.addNode("other-kubernetes-minion")
+	newest_pod := cluster.addPod(pod_name, pod_uid, namespace, other_node)
+	assert.Nil(newest_pod)
+}
+
+// TestUpdateTime tests the sanity of updateTime.
+func TestUpdateTime(t *testing.T) {
+	cluster := newRealCluster()
+	stamp := time.Now()
+
+	assert.NotEqual(t, cluster.timestamp, stamp)
+	cluster.updateTime(stamp)
+	assert.Equal(t, cluster.timestamp, stamp)
+}

--- a/schema/util.go
+++ b/schema/util.go
@@ -20,8 +20,8 @@ import (
 	"github.com/GoogleCloudPlatform/heapster/store"
 )
 
-// maxTimestamp returns its largest time.Time argument
-func maxTimestamp(first time.Time, second time.Time) time.Time {
+// latestTimestamp returns its largest time.Time argument
+func latestTimestamp(first time.Time, second time.Time) time.Time {
 	if first.After(second) {
 		return first
 	}

--- a/schema/util.go
+++ b/schema/util.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/heapster/store"
 )
 
+// maxTimestamp returns its largest time.Time argument
 func maxTimestamp(first time.Time, second time.Time) time.Time {
 	if first.After(second) {
 		return first
@@ -27,8 +28,10 @@ func maxTimestamp(first time.Time, second time.Time) time.Time {
 	return second
 }
 
+// newInfoType is an InfoType Constructor, which returns a new InfoType.
+// Initial fields for the new InfoType can be provided as arguments.
+// A nil argument results in a newly-allocated map for that field.
 func newInfoType(metrics map[string]*store.TimeStore, labels map[string]string) InfoType {
-	// InfoType Constructor
 	if metrics == nil {
 		metrics = make(map[string]*store.TimeStore)
 	}

--- a/schema/util_test.go
+++ b/schema/util_test.go
@@ -22,14 +22,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestMaxTimestamp tests all flows of maxTimeStamp
-func TestMaxTimestamp(t *testing.T) {
+// TestLatestsTimestamp tests all flows of latestTimeStamp
+func TestLatestTimestamp(t *testing.T) {
 	assert := assert.New(t)
 	past := time.Unix(1434212566, 0)
 	future := time.Unix(1434212800, 0)
-	assert.Equal(maxTimestamp(past, future), future)
-	assert.Equal(maxTimestamp(future, past), future)
-	assert.Equal(maxTimestamp(future, future), future)
+	assert.Equal(latestTimestamp(past, future), future)
+	assert.Equal(latestTimestamp(future, past), future)
+	assert.Equal(latestTimestamp(future, future), future)
 }
 
 // TestNewInfoType tests both flows of the InfoType constructor.

--- a/schema/util_test.go
+++ b/schema/util_test.go
@@ -1,0 +1,55 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/heapster/store"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMaxTimestamp tests all flows of maxTimeStamp
+func TestMaxTimestamp(t *testing.T) {
+	assert := assert.New(t)
+	past := time.Unix(1434212566, 0)
+	future := time.Unix(1434212800, 0)
+	assert.Equal(maxTimestamp(past, future), future)
+	assert.Equal(maxTimestamp(future, past), future)
+	assert.Equal(maxTimestamp(future, future), future)
+}
+
+// TestNewInfoType tests both flows of the InfoType constructor.
+func TestNewInfoType(t *testing.T) {
+	var (
+		metrics = make(map[string]*store.TimeStore)
+		labels  = make(map[string]string)
+	)
+	new_store := store.NewGCStore(store.NewTimeStore(), time.Hour)
+	metrics["test"] = &new_store
+	labels["name"] = "test"
+	assert := assert.New(t)
+
+	// Invocation with no parameters
+	new_infotype := newInfoType(nil, nil)
+	assert.Empty(new_infotype.Metrics)
+	assert.Empty(new_infotype.Labels)
+
+	// Invocation with both parameters
+	new_infotype = newInfoType(metrics, labels)
+	assert.Equal(new_infotype.Metrics, metrics)
+	assert.Equal(new_infotype.Labels, labels)
+}


### PR DESCRIPTION
Part 3 of #342 
Includes the following:
- Add methods for Namespaces, Nodes and Pods
- Unit tests for adders and the existing util functions

Changes based on comments from #358:
- lock moved inside the cluster object again
- Get methods have more verbose comments, clearly explaining inputs and outputs

@vishh @rjnagal the next PR, Schema 4, will include utility functions that operate on TimeStores, along with their unit tests.