### PR TITLE
[Schema 5] Update methods

### DIFF
--- a/schema/types.go
+++ b/schema/types.go
@@ -24,7 +24,7 @@ import (
 
 type Cluster interface {
 	// The Update operation populates the Cluster from a cache.
-	Update(*cache.Cache) error
+	Update(cache.Cache) error
 
 	// The Get operations extract internal types from the Cluster.
 	// The returned time.Time values signify the latest metric timestamp in the cluster.

--- a/schema/util.go
+++ b/schema/util.go
@@ -43,3 +43,19 @@ func newInfoType(metrics map[string]*store.TimeStore, labels map[string]string) 
 		Labels:  labels,
 	}
 }
+
+// addContainerToMap creates or finds a ContainerInfo element under a map[string]*ContainerInfo
+func addContainerToMap(container_name string, dict map[string]*ContainerInfo) *ContainerInfo {
+	var container_ptr *ContainerInfo
+
+	if val, ok := dict[container_name]; ok {
+		// A container already exists under that name, return the address
+		container_ptr = val
+	} else {
+		container_ptr = &ContainerInfo{
+			InfoType: newInfoType(nil, nil),
+		}
+		dict[container_name] = container_ptr
+	}
+	return container_ptr
+}

--- a/schema/util_test.go
+++ b/schema/util_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/heapster/store"
 )
 
-// TestLatestsTimestamp tests all flows of latestTimeStamp
+// TestLatestsTimestamp tests all flows of latestTimeStamp.
 func TestLatestTimestamp(t *testing.T) {
 	assert := assert.New(t)
 	past := time.Unix(1434212566, 0)
@@ -53,4 +53,23 @@ func TestNewInfoType(t *testing.T) {
 	new_infotype = newInfoType(metrics, labels)
 	assert.Equal(new_infotype.Metrics, metrics)
 	assert.Equal(new_infotype.Labels, labels)
+}
+
+// TestAddContainerToMap tests all the flows of addContainerToMap.
+func TestAddContainerToMap(t *testing.T) {
+	new_map := make(map[string]*ContainerInfo)
+
+	// First Call: A new ContainerInfo is created
+	cinfo := addContainerToMap("new_container", new_map)
+
+	assert := assert.New(t)
+	assert.NotNil(cinfo)
+	assert.NotNil(cinfo.Metrics)
+	assert.NotNil(cinfo.Labels)
+	assert.Equal(new_map["new_container"], cinfo)
+
+	// Second Call: A ContainerInfo is already available for that key
+	new_cinfo := addContainerToMap("new_container", new_map)
+	assert.Equal(new_map["new_container"], new_cinfo)
+	assert.Equal(cinfo, new_cinfo)
 }


### PR DESCRIPTION
Part 5 of #342 
This PR implements the Update(Cache) method along with all appropriate submethods.
The Update method introduces the functionality of populating the cluster with new metrics from a Cache.
In the next PR, the Update method will be extended to also extract aggregated metrics (but not derived stats yet)

Additions (with test coverage %):
- Update(*Cache): updates the cluster from a *Cache. (87.5%)
- updateNode: updates/adds a node in the cluster from a *ContainerElement. (100%)
- updatePod: updates/adds a pod in the cluster from a *PodElement. (93.3%)
- updatePodContainer: updates/adds a Pod Container from a *ContainerElement. (100%)
- updateFreeContainer: updates/adds a Free Container from a *ContainerElement. (100%)
- addContainerToMap (utility function): creates or finds a *ContainerInfo under a specified map. (100%)

Note on coverage: The functions without 100% coverage have untested error-handling branches for errors that are being tested in other unit tests. These branches ensure the propagation of errors throughout the call stack.

Extra: standardized variable initializations among unit tests

Percentage of testing code in this PR: 76%
cc @rjnagal @vishh 