### PR TITLE
Make the system container names user friendly

### DIFF
--- a/sinks/cache/cache_impl.go
+++ b/sinks/cache/cache_impl.go
@@ -22,6 +22,8 @@ import (
 	"github.com/GoogleCloudPlatform/heapster/store"
 )
 
+const rootContainer = "/"
+
 type containerElement struct {
 	Metadata
 	metrics store.TimeStore
@@ -50,8 +52,6 @@ type realCache struct {
 	nodes map[string]*nodeElement
 	lock  sync.RWMutex
 }
-
-const rootContainer = "/"
 
 func (rc *realCache) newContainerElement() *containerElement {
 	return &containerElement{


### PR DESCRIPTION
Essentially this PR removes the "/" prefix from system containers. Over time, we will have to update this logic to handle system containers in systemd systems.
The e2e test has been upgraded to capture the presence of system containers on all the hosts. 