### PR TITLE
Cumulative Moving Average TimeStore

### DIFF
--- a/store/cma_store.go
+++ b/store/cma_store.go
@@ -1,0 +1,141 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// cmaStore maintains the cumulative moving average of values at a specific Timestamp.
+// cmaStore is an implementation of TimeStore where the values are casted as uint64.
+// TODO(alex): avoid duplication with in_memory.
+type cmaStore struct {
+	// buffer is a list of tpContainers that is sequenced in a time-descending order.
+	buffer *list.List
+	// rwLock protects all operations on the buffer.
+	rwLock sync.RWMutex
+}
+
+// tpContainer is the actual struct that is being stored in the buffer that implements cmaStore.
+// tpContainer contains a TimePoint and the count of TimePoints with the same timestamp that
+// have been averaged to a single tpContainer. The TimePoint.Value field contains the average
+// of all these TimePoints.
+type tpContainer struct {
+	TimePoint
+	count int
+}
+
+func (ts *cmaStore) Put(tp TimePoint) error {
+	if tp.Value == nil {
+		return fmt.Errorf("cannot store TimePoint with nil data")
+	}
+	if (tp.Timestamp == time.Time{}) {
+		return fmt.Errorf("cannot store TimePoint with zero timestamp")
+	}
+	ts.rwLock.Lock()
+	defer ts.rwLock.Unlock()
+	newTPC := tpContainer{
+		TimePoint: tp,
+		count:     1,
+	}
+	if ts.buffer.Len() == 0 {
+		glog.V(5).Infof("put pushfront: %v, %v", tp.Timestamp, tp.Value)
+		ts.buffer.PushFront(newTPC)
+		return nil
+	}
+	for elem := ts.buffer.Front(); elem != nil; elem = elem.Next() {
+		curr := elem.Value.(tpContainer)
+		if tp.Timestamp.Equal(curr.Timestamp) {
+			// If an element with that timestamp exists, update its average and count
+			newVal := tp.Value.(uint64)
+			n := uint64(curr.count)
+			oldAvg := curr.Value.(uint64)
+			curr.Value = uint64((newVal + (n * oldAvg)) / (n + 1))
+			curr.count = curr.count + 1
+			elem.Value = curr
+			return nil
+		} else if tp.Timestamp.After(curr.Timestamp) {
+			glog.V(5).Infof("put insert before: %v, %v, %v", elem, tp.Timestamp, tp.Value)
+			ts.buffer.InsertBefore(newTPC, elem)
+			return nil
+		}
+	}
+	glog.V(5).Infof("put pushback: %v, %v", tp.Timestamp, tp.Value)
+	ts.buffer.PushBack(newTPC)
+	return nil
+}
+
+func (ts *cmaStore) Get(start, end time.Time) []TimePoint {
+	zeroTime := time.Time{}
+	ts.rwLock.RLock()
+	defer ts.rwLock.RUnlock()
+	if ts.buffer.Len() == 0 {
+		return nil
+	}
+	result := []TimePoint{}
+	for elem := ts.buffer.Front(); elem != nil; elem = elem.Next() {
+		tpc := elem.Value.(tpContainer)
+		entry := tpc.TimePoint
+
+		// Skip entries until the first one after start
+		if (start != zeroTime) && entry.Timestamp.Before(start) {
+			continue
+		}
+		// Add all entries whose timestamp is not after end.
+		if (end == time.Time{}) || !entry.Timestamp.After(end) {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+func (ts *cmaStore) Delete(start, end time.Time) error {
+	ts.rwLock.Lock()
+	defer ts.rwLock.Unlock()
+	if ts.buffer.Len() == 0 {
+		return nil
+	}
+	if (end != time.Time{}) && !end.After(start) {
+		return fmt.Errorf("end time %v is not after start time %v", end, start)
+	}
+	// Assuming that deletes will happen more frequently for older data.
+	elem := ts.buffer.Back()
+	for elem != nil {
+		tpc := elem.Value.(tpContainer)
+		if (end != time.Time{}) && tpc.Timestamp.After(end) {
+			// If we have reached an entry which is more recent than 'end' stop iterating.
+			break
+		}
+		oldElem := elem
+		elem = elem.Prev()
+
+		// Skip entries before the start time.
+		if !tpc.Timestamp.Before(start) {
+			ts.buffer.Remove(oldElem)
+		}
+	}
+	return nil
+}
+
+func NewCMAStore() TimeStore {
+	return &cmaStore{
+		buffer: list.New(),
+	}
+}

--- a/store/cma_store_test.go
+++ b/store/cma_store_test.go
@@ -1,0 +1,138 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCMAInit(t *testing.T) {
+	store := NewCMAStore()
+	data := store.Get(time.Now().Add(-time.Minute), time.Now())
+	assert.Empty(t, len(data), time.Now())
+}
+
+func TestCMANilInsert(t *testing.T) {
+	store := NewCMAStore()
+	assert.Error(t, store.Put(TimePoint{time.Now(), nil}))
+}
+
+func TestCMAInsertNormal(t *testing.T) {
+	store := NewCMAStore()
+	now := time.Now()
+	assert := assert.New(t)
+	assert.NoError(store.Put(TimePoint{now, uint64(2)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-time.Second), uint64(1)}))
+	assert.NoError(store.Put(TimePoint{now.Add(time.Second), uint64(3)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-2 * time.Second), uint64(0)}))
+	actual := store.Get(time.Time{}, now)
+	require.Len(t, actual, 3)
+	actual = store.Get(time.Time{}, time.Time{})
+	require.Len(t, actual, 4)
+}
+
+func TestCMAInsertTime(t *testing.T) {
+	zeroTime := time.Time{}
+	store := NewCMAStore()
+	now := time.Now()
+	assert := assert.New(t)
+
+	// Errors
+	assert.Error(store.Put(TimePoint{zeroTime, uint64(2)}))
+	assert.Error(store.Put(TimePoint{zeroTime, nil}))
+
+	assert.NoError(store.Put(TimePoint{now, uint64(2)}))
+	assert.NoError(store.Put(TimePoint{now, uint64(6)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(20)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(10)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(1000)}))
+
+	// Get Invocation with values 2 and 4
+	actual := store.Get(zeroTime, now)
+	fmt.Println(actual)
+	require.Len(t, actual, 1)
+	assert.Equal(actual[0].Value, uint64(4))
+
+	// Get Invocation with values 0, 20, 10 and 1000
+	actual = store.Get(zeroTime, zeroTime)
+	require.Len(t, actual, 2)
+	assert.Equal(actual[0].Value, uint64(257)) // 257.5 rounded down
+	assert.Equal(actual[1].Value, uint64(4))
+
+	// Get correct averages after new puts
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-2 * time.Hour), uint64(999)}))
+	actual = store.Get(zeroTime, zeroTime)
+	require.Len(t, actual, 3)
+	assert.Equal(actual[0].Value, uint64(126)) // 128.75 approximation
+	assert.Equal(actual[1].Value, uint64(4))
+	assert.Equal(actual[2].Value, uint64(999))
+
+	// Get up until a point
+	assert.NoError(store.Put(TimePoint{now.Add(-time.Hour), uint64(30)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-time.Hour), uint64(40)}))
+	actual = store.Get(zeroTime, now.Add(-time.Hour))
+	require.Len(t, actual, 2)
+	assert.Equal(actual[0].Value, uint64(35))
+	assert.Equal(actual[1].Value, uint64(999))
+}
+
+func TestCMADelete(t *testing.T) {
+	zeroTime := time.Time{}
+	store := NewCMAStore()
+	now := time.Now()
+	assert := assert.New(t)
+
+	// Invocation with empty buffer
+	assert.NoError(store.Delete(now, now.Add(time.Minute)))
+
+	assert.NoError(store.Put(TimePoint{now, uint64(2)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-time.Second), uint64(1)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(time.Second), uint64(3)}))
+
+	// Normal Invocation
+	assert.NoError(store.Delete(now.Add(-time.Second), now))
+	actual := store.Get(now.Add(-time.Second), zeroTime)
+	require.Len(t, actual, 1)
+	assert.Equal(uint64(3), actual[0].Value.(uint64))
+	assert.NoError(store.Delete(zeroTime, zeroTime))
+	assert.Empty(store.Get(zeroTime, zeroTime))
+
+	// Invocation with no affected data
+	assert.NoError(store.Put(TimePoint{now, uint64(2)}))
+	assert.NoError(store.Delete(zeroTime, now.Add(-time.Minute)))
+	actual = store.Get(zeroTime, zeroTime)
+	assert.Len(actual, 1)
+	assert.Equal(actual[0].Value, uint64(2))
+
+	// Invocation with start time
+	assert.NoError(store.Delete(now.Add(2*time.Minute), zeroTime))
+	actual = store.Get(zeroTime, zeroTime)
+	assert.Len(actual, 1)
+	assert.Equal(actual[0].Value, uint64(2))
+
+	// Invocation with error (start after end)
+	assert.Error(store.Delete(now, now.Add(-time.Minute)))
+}


### PR DESCRIPTION
Added a CMA TimeStore implementation, cma_store. 

All TimePoints in the cma_store have unique timestamps. When two or more TimePoints with the same timestamp are Put in the store, they are converted to a single TimePoint with a Value that represents the average of all TimePoints with the same timestamp.

cma_store can be used as the basis for a TimeStore that can maintain derived stats, as it is already making the assumption that Value is a uint64.

100% Test Coverage

cc @rjnagal @vishh