### PR TITLE
[Schema 6] Metric aggregation step

### DIFF
--- a/schema/aggr.go
+++ b/schema/aggr.go
@@ -1,0 +1,202 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/heapster/store"
+)
+
+// aggregationStep performs a Metric Aggregation step on the cluster.
+// The Metrics fields of all Namespaces, Pods and the Cluster are populated,
+// by Timeseries summation of the respective Metrics fields.
+// aggregationStep should be called after new data is present in the cluster,
+// but before the cluster timestamp is updated.
+func (rc *realCluster) aggregationStep() error {
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+
+	// Perform Node Metric Aggregation
+	node_c := make(chan error)
+	go rc.aggregateNodeMetrics(node_c)
+
+	// Initiate bottom-up aggregation for Kubernetes stats
+	kube_c := make(chan error)
+	go rc.aggregateKubeMetrics(kube_c)
+
+	err := <-node_c
+	if err != nil {
+		return err
+	}
+	err = <-kube_c
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// aggregateNodeMetrics populates the Cluster.InfoType.Metrics field by adding up all node metrics.
+// Assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) aggregateNodeMetrics(c chan error) {
+	if len(rc.Nodes) == 0 {
+		// Fail silently if the cluster has no nodes
+		c <- nil
+		return
+	}
+
+	sources := []*InfoType{}
+	for _, node := range rc.Nodes {
+		sources = append(sources, &(node.InfoType))
+	}
+	c <- rc.aggregateMetrics(&rc.ClusterInfo.InfoType, sources)
+}
+
+// aggregateKubeMetrics initiates depth-first aggregation of Kubernetes metrics.
+// Assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) aggregateKubeMetrics(c chan error) {
+	if len(rc.Namespaces) == 0 {
+		// Fail silently if the cluster has no namespaces
+		c <- nil
+		return
+	}
+
+	// Perform aggregation for all the namespaces
+	chans := make([]chan error, 0)
+	for _, namespace := range rc.Namespaces {
+		chans = append(chans, make(chan error))
+		go rc.aggregateNamespaceMetrics(namespace, chans[len(chans)-1])
+	}
+
+	for _, channel := range chans {
+		err := <-channel
+		if err != nil {
+			c <- err
+		}
+	}
+	c <- nil
+}
+
+// aggregateNamespaceMetrics populates a NamespaceInfo.Metrics field by aggregating all PodInfo.
+// Assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) aggregateNamespaceMetrics(namespace *NamespaceInfo, c chan error) {
+	if namespace == nil {
+		c <- fmt.Errorf("nil Namespace pointer passed for aggregation")
+		return
+	}
+	if len(namespace.Pods) == 0 {
+		// Fail silently if the namespace has no pods
+		c <- nil
+		return
+	}
+
+	// Perform aggregation for all the Pods
+	chans := make([]chan error, 0)
+	for _, pod := range namespace.Pods {
+		chans = append(chans, make(chan error))
+		go rc.aggregatePodMetrics(pod, chans[len(chans)-1])
+	}
+
+	for _, channel := range chans {
+		err := <-channel
+		if err != nil {
+			c <- err
+			return
+		}
+	}
+
+	// Collect the Pod InfoTypes after aggregation is complete
+	sources := []*InfoType{}
+	for _, pod := range namespace.Pods {
+		sources = append(sources, &(pod.InfoType))
+	}
+	c <- rc.aggregateMetrics(&namespace.InfoType, sources)
+}
+
+// aggregatePodMetrics populates a PodInfo.Metrics field by aggregating all ContainerInfo.
+// Assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) aggregatePodMetrics(pod *PodInfo, c chan error) {
+	if pod == nil {
+		c <- fmt.Errorf("nil Pod pointer passed for aggregation")
+		return
+	}
+	if len(pod.Containers) == 0 {
+		// Fail silently if the pod has no containers
+		c <- nil
+		return
+	}
+
+	// Collect the Container InfoTypes
+	sources := []*InfoType{}
+	for _, container := range pod.Containers {
+		sources = append(sources, &(container.InfoType))
+	}
+	c <- rc.aggregateMetrics(&pod.InfoType, sources)
+}
+
+// aggregateMetrics populates an InfoType by adding metrics across a slice of InfoTypes.
+// Only metrics taken after the cluster timestamp are affected.
+// Assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) aggregateMetrics(target *InfoType, sources []*InfoType) error {
+	zeroTime := time.Time{}
+
+	if target == nil {
+		return fmt.Errorf("nil InfoType pointer provided as aggregation target")
+	}
+	if len(sources) == 0 {
+		return fmt.Errorf("empty sources slice provided")
+	}
+	for _, source := range sources {
+		if source == nil {
+			return fmt.Errorf("nil InfoType pointer provided as an aggregation source")
+		}
+		if source == target {
+			return fmt.Errorf("target InfoType pointer is provided as a source")
+		}
+	}
+
+	// Create a map of []TimePoint as a timeseries accumulator per metric
+	newMetrics := make(map[string][]store.TimePoint)
+
+	// Reduce the sources slice with timeseries addition for each metric
+	for _, info := range sources {
+		for key, ts := range info.Metrics {
+			_, ok := newMetrics[key]
+			if !ok {
+				// Metric does not exist on target map, create a new timeseries
+				newMetrics[key] = []store.TimePoint{}
+			}
+			// Perform timeseries addition between the accumulator and the current source
+			sourceTS := (*ts).Get(rc.timestamp, zeroTime)
+			newMetrics[key] = addMatchingTimeseries(newMetrics[key], sourceTS)
+		}
+	}
+
+	// Put all the new values in the TimeStores under target
+	for key, tpSlice := range newMetrics {
+		_, ok := target.Metrics[key]
+		if !ok {
+			// Metric does not exist on target InfoType, create TimeStore
+			newTS := rc.tsConstructor()
+			target.Metrics[key] = &newTS
+		}
+		for _, tp := range tpSlice {
+			(*target.Metrics[key]).Put(tp)
+		}
+	}
+	return nil
+}

--- a/schema/aggr_test.go
+++ b/schema/aggr_test.go
@@ -1,0 +1,205 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/GoogleCloudPlatform/heapster/store"
+)
+
+// TestAggregateNodeMetricsEmpty tests the empty flow of aggregateNodeMetrics.
+// The normal flow is tested through TestUpdate.
+func TestAggregateNodeMetricsEmpty(t *testing.T) {
+	var (
+		cluster = newRealCluster(newTimeStore, time.Minute)
+		c       = make(chan error)
+		assert  = assert.New(t)
+	)
+
+	// Invocation with empty cluster
+	go cluster.aggregateNodeMetrics(c)
+	assert.NoError(<-c)
+	assert.Empty(cluster.Nodes)
+	assert.Empty(cluster.Metrics)
+}
+
+// TestAggregateKubeMetricsError tests the error flows of aggregateKubeMetrics.
+// The normal flow is tested through TestUpdate.
+func TestAggregateKubeMetricsEmpty(t *testing.T) {
+	var (
+		cluster = newRealCluster(newTimeStore, time.Minute)
+		c       = make(chan error)
+		assert  = assert.New(t)
+	)
+
+	// Invocation with empty cluster
+	go cluster.aggregateKubeMetrics(c)
+	assert.NoError(<-c)
+	assert.Empty(cluster.Namespaces)
+
+	// Error propagation from aggregateNamespaceMetrics
+	cluster.Namespaces["default"] = nil
+	go cluster.aggregateKubeMetrics(c)
+	assert.Error(<-c)
+	assert.NotEmpty(cluster.Namespaces)
+}
+
+// TestAggregateNamespaceMetrics tests the error flows of aggregateNamespaceMetrics.
+// The normal flow is tested through TestUpdate.
+func TestAggregateNamespaceMetricsError(t *testing.T) {
+	var (
+		cluster = newRealCluster(newTimeStore, time.Minute)
+		c       = make(chan error)
+		assert  = assert.New(t)
+	)
+
+	// Invocation with nil namespace
+	go cluster.aggregateNamespaceMetrics(nil, c)
+	assert.Error(<-c)
+	assert.Empty(cluster.Namespaces)
+
+	// Invocation for a namespace with no pods
+	ns := cluster.addNamespace("default")
+	go cluster.aggregateNamespaceMetrics(ns, c)
+	assert.NoError(<-c)
+	assert.Len(ns.Pods, 0)
+
+	// Error propagation from aggregatePodMetrics
+	ns.Pods["pod1"] = nil
+	go cluster.aggregateNamespaceMetrics(ns, c)
+	assert.Error(<-c)
+}
+
+// TestAggregatePodMetricsError tests the error flows of aggregatePodMetrics.
+// The normal flow is tested through TestUpdate.
+func TestAggregatePodMetricsError(t *testing.T) {
+	var (
+		cluster = newRealCluster(newTimeStore, time.Minute)
+		c       = make(chan error)
+		assert  = assert.New(t)
+	)
+	ns := cluster.addNamespace("default")
+	node := cluster.addNode("newnode")
+	pod := cluster.addPod("pod1", "uid111", ns, node)
+
+	// Invocation with nil pod
+	go cluster.aggregatePodMetrics(nil, c)
+	assert.Error(<-c)
+
+	// Invocation with empty pod
+	go cluster.aggregatePodMetrics(pod, c)
+	assert.NoError(<-c)
+
+	// Invocation with a normal pod
+	addContainerToMap("new_container", pod.Containers)
+	addContainerToMap("new_container2", pod.Containers)
+	go cluster.aggregatePodMetrics(pod, c)
+	assert.NoError(<-c)
+}
+
+// TestAggregateMetricsError tests the error flows of aggregateMetrics.
+func TestAggregateMetricsError(t *testing.T) {
+	var (
+		cluster    = newRealCluster(newTimeStore, time.Minute)
+		targetInfo = InfoType{
+			Metrics: make(map[string]*store.TimeStore),
+			Labels:  make(map[string]string),
+		}
+		srcInfo = InfoType{
+			Metrics: make(map[string]*store.TimeStore),
+			Labels:  make(map[string]string),
+		}
+		assert = assert.New(t)
+	)
+
+	// Invocation with nil first argument
+	sources := []*InfoType{&srcInfo}
+	assert.Error(cluster.aggregateMetrics(nil, sources))
+
+	// Invocation with empty second argument
+	sources = []*InfoType{}
+	assert.Error(cluster.aggregateMetrics(&targetInfo, sources))
+
+	// Invocation with a nil element in the second argument
+	sources = []*InfoType{&srcInfo, nil}
+	assert.Error(cluster.aggregateMetrics(&targetInfo, sources))
+
+	// Invocation with the target being also part of sources
+	sources = []*InfoType{&srcInfo, &targetInfo}
+	assert.Error(cluster.aggregateMetrics(&targetInfo, sources))
+}
+
+// TestAggregateMetricsNormal tests the normal flows of aggregateMetrics.
+func TestAggregateMetricsNormal(t *testing.T) {
+	var (
+		cluster    = newRealCluster(newTimeStore, time.Minute)
+		targetInfo = InfoType{
+			Metrics: make(map[string]*store.TimeStore),
+			Labels:  make(map[string]string),
+		}
+		srcInfo1 = InfoType{
+			Metrics: make(map[string]*store.TimeStore),
+			Labels:  make(map[string]string),
+		}
+		srcInfo2 = InfoType{
+			Metrics: make(map[string]*store.TimeStore),
+			Labels:  make(map[string]string),
+		}
+		now    = time.Now().Round(time.Minute)
+		assert = assert.New(t)
+	)
+
+	newTS := newTimeStore()
+	newTS.Put(store.TimePoint{
+		Timestamp: now,
+		Value:     uint64(5000),
+	})
+	newTS.Put(store.TimePoint{
+		Timestamp: now.Add(time.Hour),
+		Value:     uint64(3000),
+	})
+	newTS2 := newTimeStore()
+	newTS2.Put(store.TimePoint{
+		Timestamp: now,
+		Value:     uint64(2000),
+	})
+	newTS2.Put(store.TimePoint{
+		Timestamp: now.Add(time.Hour),
+		Value:     uint64(3500),
+	})
+	newTS2.Put(store.TimePoint{
+		Timestamp: now.Add(2 * time.Hour),
+		Value:     uint64(9000),
+	})
+
+	srcInfo1.Metrics[memUsage] = &newTS
+	srcInfo2.Metrics[memUsage] = &newTS2
+	sources := []*InfoType{&srcInfo1, &srcInfo2}
+
+	// Normal Invocation
+	cluster.aggregateMetrics(&targetInfo, sources)
+
+	assert.NotNil(targetInfo.Metrics[memUsage])
+	targetMemTS := *(targetInfo.Metrics[memUsage])
+	res := targetMemTS.Get(time.Time{}, time.Time{})
+	assert.Len(res, 3)
+	assert.Equal(res[0].Value, uint64(9000))
+	assert.Equal(res[1].Value, uint64(6500))
+	assert.Equal(res[2].Value, uint64(7000))
+}

--- a/schema/types.go
+++ b/schema/types.go
@@ -28,10 +28,7 @@ type Cluster interface {
 
 	// The Get operations extract internal types from the Cluster.
 	// The returned time.Time values signify the latest metric timestamp in the cluster.
-	// TODO(alex): Returning pointers is NOT safe, will be addressed in a later PR
-	GetAllClusterData() (*ClusterInfo, time.Time, error)
-	GetAllNodeData(string) (*NodeInfo, time.Time, error)
-	GetAllPodData(string, string) (*PodInfo, time.Time, error)
+	GetClusterMetrics(time.Time) (map[string][]store.TimePoint, time.Time, error)
 }
 
 // realCluster is an implementation of the Cluster interface.
@@ -41,6 +38,7 @@ type realCluster struct {
 	timestamp     time.Time
 	lock          sync.RWMutex
 	tsConstructor func() store.TimeStore
+	resolution    time.Duration
 	ClusterInfo
 }
 

--- a/schema/util.go
+++ b/schema/util.go
@@ -59,3 +59,71 @@ func addContainerToMap(container_name string, dict map[string]*ContainerInfo) *C
 	}
 	return container_ptr
 }
+
+// addTimePoints adds the values of two TimePoints as uint64.
+// addTimePoints returns a new TimePoint with the added Value fields
+// and the Timestamp of the first TimePoint.
+func addTimePoints(tp1 store.TimePoint, tp2 store.TimePoint) store.TimePoint {
+	return store.TimePoint{
+		Timestamp: tp1.Timestamp,
+		Value:     tp1.Value.(uint64) + tp2.Value.(uint64),
+	}
+}
+
+// popTPSlice pops the first element of a TimePoint Slice, removing it from the slice.
+// popTPSlice receives a *[]TimePoint and returns its first element.
+func popTPSlice(tps_ptr *[]store.TimePoint) *store.TimePoint {
+	if tps_ptr == nil {
+		return nil
+	}
+	tps := *tps_ptr
+	if len(tps) == 0 {
+		return nil
+	}
+	res := tps[0]
+	if len(tps) == 1 {
+		(*tps_ptr) = tps[0:0]
+	}
+	(*tps_ptr) = tps[1:]
+	return &res
+}
+
+// addMatchingTimeseries performs addition over two timeseries with unique timestamps.
+// addMatchingTimeseries returns a []TimePoint of the resulting aggregated.
+// Assumes time-descending order of both []TimePoint parameters and the return slice.
+func addMatchingTimeseries(left []store.TimePoint, right []store.TimePoint) []store.TimePoint {
+	var cur_left *store.TimePoint
+	var cur_right *store.TimePoint
+	result := []store.TimePoint{}
+
+	// Merge timeseries into result until either one is empty
+	cur_left = popTPSlice(&left)
+	cur_right = popTPSlice(&right)
+	for cur_left != nil && cur_right != nil {
+		if cur_left.Timestamp.Equal(cur_right.Timestamp) {
+			result = append(result, addTimePoints(*cur_left, *cur_right))
+			cur_left = popTPSlice(&left)
+			cur_right = popTPSlice(&right)
+		} else if cur_left.Timestamp.After(cur_right.Timestamp) {
+			result = append(result, *cur_left)
+			cur_left = popTPSlice(&left)
+		} else {
+			result = append(result, *cur_right)
+			cur_right = popTPSlice(&right)
+		}
+	}
+	if cur_left == nil && cur_right != nil {
+		result = append(result, *cur_right)
+	} else if cur_left != nil && cur_right == nil {
+		result = append(result, *cur_left)
+	}
+
+	// Append leftover elements from non-empty timeseries
+	if len(left) > 0 {
+		result = append(result, left...)
+	} else if len(right) > 0 {
+		result = append(result, right...)
+	}
+
+	return result
+}

--- a/schema/util_test.go
+++ b/schema/util_test.go
@@ -23,6 +23,14 @@ import (
 	"github.com/GoogleCloudPlatform/heapster/store"
 )
 
+// newTimePoint is a helper function that constructs TimePoints for other unit tests.
+func newTimePoint(stamp time.Time, val interface{}) store.TimePoint {
+	return store.TimePoint{
+		Timestamp: stamp,
+		Value:     val,
+	}
+}
+
 // TestLatestsTimestamp tests all flows of latestTimeStamp.
 func TestLatestTimestamp(t *testing.T) {
 	assert := assert.New(t)
@@ -39,7 +47,7 @@ func TestNewInfoType(t *testing.T) {
 		metrics = make(map[string]*store.TimeStore)
 		labels  = make(map[string]string)
 	)
-	new_store := store.NewGCStore(store.NewTimeStore(), time.Hour)
+	new_store := newTimeStore()
 	metrics["test"] = &new_store
 	labels["name"] = "test"
 	assert := assert.New(t)
@@ -72,4 +80,164 @@ func TestAddContainerToMap(t *testing.T) {
 	new_cinfo := addContainerToMap("new_container", new_map)
 	assert.Equal(new_map["new_container"], new_cinfo)
 	assert.Equal(cinfo, new_cinfo)
+}
+
+// TestAddTimePoints tests all flows of addTimePoints.
+func TestAddTimePoints(t *testing.T) {
+	var (
+		tp1 = store.TimePoint{
+			Timestamp: time.Unix(1434212800, 0),
+			Value:     uint64(500),
+		}
+		tp2 = store.TimePoint{
+			Timestamp: time.Unix(1434212805, 0),
+			Value:     uint64(700),
+		}
+		assert = assert.New(t)
+	)
+	new_tp := addTimePoints(tp1, tp2)
+	assert.Equal(new_tp.Timestamp, tp1.Timestamp)
+	assert.Equal(new_tp.Value.(uint64), tp1.Value.(uint64)+tp2.Value.(uint64))
+}
+
+// TestPopTPSlice tests all flows of PopTPSlice.
+func TestPopTPSlice(t *testing.T) {
+	var (
+		tp1 = store.TimePoint{
+			Timestamp: time.Now(),
+			Value:     uint64(3),
+		}
+		tp2 = store.TimePoint{
+			Timestamp: time.Now(),
+			Value:     uint64(4),
+		}
+		assert = assert.New(t)
+	)
+
+	// Invocations with no popped element
+	assert.Nil(popTPSlice(nil))
+	assert.Nil(popTPSlice(&[]store.TimePoint{}))
+
+	// Invocation with one element
+	tps := []store.TimePoint{tp1}
+	res := popTPSlice(&tps)
+	assert.Equal(*res, tp1)
+	assert.Empty(tps)
+
+	// Invocation with two elements
+	tps = []store.TimePoint{tp1, tp2}
+	res = popTPSlice(&tps)
+	assert.Equal(*res, tp1)
+	assert.Len(tps, 1)
+	assert.Equal(tps[0], tp2)
+}
+
+// TestAddMatchingTimeseries tests the normal flow of addMatchingTimeseries.
+func TestAddMatchingTimeseries(t *testing.T) {
+	var (
+		tp11 = store.TimePoint{
+			Timestamp: time.Unix(1434212800, 0),
+			Value:     uint64(4),
+		}
+		tp21 = store.TimePoint{
+			Timestamp: time.Unix(1434212805, 0),
+			Value:     uint64(9),
+		}
+		tp31 = store.TimePoint{
+			Timestamp: time.Unix(1434212807, 0),
+			Value:     uint64(10),
+		}
+		tp41 = store.TimePoint{
+			Timestamp: time.Unix(1434212850, 0),
+			Value:     uint64(533),
+		}
+
+		tp12 = store.TimePoint{
+			Timestamp: time.Unix(1434212800, 0),
+			Value:     uint64(4),
+		}
+		tp22 = store.TimePoint{
+			Timestamp: time.Unix(1434212806, 0),
+			Value:     uint64(8),
+		}
+		tp32 = store.TimePoint{
+			Timestamp: time.Unix(1434212807, 0),
+			Value:     uint64(11),
+		}
+		tp42 = store.TimePoint{
+			Timestamp: time.Unix(1434212851, 0),
+			Value:     uint64(534),
+		}
+		tp52 = store.TimePoint{
+			Timestamp: time.Unix(1434212859, 0),
+			Value:     uint64(538),
+		}
+		assert = assert.New(t)
+	)
+	// Invocation with 1+1 data points
+	tps1 := []store.TimePoint{tp11}
+	tps2 := []store.TimePoint{tp12}
+	new_ts := addMatchingTimeseries(tps1, tps2)
+	assert.Len(new_ts, 1)
+	assert.Equal(new_ts[0].Timestamp, tp11.Timestamp)
+	assert.Equal(new_ts[0].Value, uint64(8))
+
+	// Invocation with 3+1 data points
+	tps1 = []store.TimePoint{tp52, tp42, tp11}
+	tps2 = []store.TimePoint{tp12}
+	new_ts = addMatchingTimeseries(tps1, tps2)
+	assert.Len(new_ts, 3)
+	assert.Equal(new_ts[0], tp52)
+	assert.Equal(new_ts[1], tp42)
+	assert.Equal(new_ts[2].Timestamp, tp11.Timestamp)
+	assert.Equal(new_ts[2].Value, tp11.Value.(uint64)+tp12.Value.(uint64))
+
+	// Invocation with 4+5 data points
+	tps1 = []store.TimePoint{tp41, tp31, tp21, tp11}
+	tps2 = []store.TimePoint{tp52, tp42, tp32, tp22, tp12}
+	new_ts = addMatchingTimeseries(tps1, tps2)
+	assert.Len(new_ts, 7)
+	assert.Equal(new_ts[0], tp52)
+	assert.Equal(new_ts[1], tp42)
+	assert.Equal(new_ts[2], tp41)
+	assert.Equal(new_ts[3].Timestamp, tp31.Timestamp)
+	assert.Equal(new_ts[3].Value, uint64(21))
+	assert.Equal(new_ts[4], tp22)
+	assert.Equal(new_ts[5], tp21)
+	assert.Equal(new_ts[6].Timestamp, tp11.Timestamp)
+	assert.Equal(new_ts[6].Value, uint64(8))
+}
+
+// TestAddMatchingTimeseriesEmpty tests the alternate flows of addMatchingTimeseries.
+// Three permutations of empty parameters are tested.
+func TestAddMatchingTimeseriesEmpty(t *testing.T) {
+	var (
+		tp12 = store.TimePoint{
+			Timestamp: time.Unix(1434212800, 0),
+			Value:     uint64(4),
+		}
+		tp22 = store.TimePoint{
+			Timestamp: time.Unix(1434212806, 0),
+			Value:     uint64(8),
+		}
+		tp32 = store.TimePoint{
+			Timestamp: time.Unix(1434212807, 0),
+			Value:     uint64(11),
+		}
+		assert = assert.New(t)
+	)
+	empty_tps := []store.TimePoint{}
+	tps := []store.TimePoint{tp12, tp22, tp32}
+
+	// First call: first argument is empty
+	new_ts := addMatchingTimeseries(empty_tps, tps)
+	assert.Equal(new_ts, tps)
+
+	// Second call: second argument is empty
+	new_ts = addMatchingTimeseries(tps, empty_tps)
+	assert.Equal(new_ts, tps)
+
+	// Third call: both arguments are empty
+	new_ts = addMatchingTimeseries(empty_tps, empty_tps)
+	assert.Equal(new_ts, empty_tps)
 }

--- a/store/cma_store.go
+++ b/store/cma_store.go
@@ -1,0 +1,141 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// cmaStore maintains the cumulative moving average of values at a specific Timestamp.
+// cmaStore is an implementation of TimeStore where the values are casted as uint64.
+// TODO(alex): avoid duplication with in_memory.
+type cmaStore struct {
+	// buffer is a list of tpContainers that is sequenced in a time-descending order.
+	buffer *list.List
+	// rwLock protects all operations on the buffer.
+	rwLock sync.RWMutex
+}
+
+// tpContainer is the actual struct that is being stored in the buffer that implements cmaStore.
+// tpContainer contains a TimePoint and the count of TimePoints with the same timestamp that
+// have been averaged to a single tpContainer. The TimePoint.Value field contains the average
+// of all these TimePoints.
+type tpContainer struct {
+	TimePoint
+	count int
+}
+
+func (ts *cmaStore) Put(tp TimePoint) error {
+	if tp.Value == nil {
+		return fmt.Errorf("cannot store TimePoint with nil data")
+	}
+	if (tp.Timestamp == time.Time{}) {
+		return fmt.Errorf("cannot store TimePoint with zero timestamp")
+	}
+	ts.rwLock.Lock()
+	defer ts.rwLock.Unlock()
+	newTPC := tpContainer{
+		TimePoint: tp,
+		count:     1,
+	}
+	if ts.buffer.Len() == 0 {
+		glog.V(5).Infof("put pushfront: %v, %v", tp.Timestamp, tp.Value)
+		ts.buffer.PushFront(newTPC)
+		return nil
+	}
+	for elem := ts.buffer.Front(); elem != nil; elem = elem.Next() {
+		curr := elem.Value.(tpContainer)
+		if tp.Timestamp.Equal(curr.Timestamp) {
+			// If an element with that timestamp exists, update its average and count
+			newVal := tp.Value.(uint64)
+			n := uint64(curr.count)
+			oldAvg := curr.Value.(uint64)
+			curr.Value = uint64((newVal + (n * oldAvg)) / (n + 1))
+			curr.count = curr.count + 1
+			elem.Value = curr
+			return nil
+		} else if tp.Timestamp.After(curr.Timestamp) {
+			glog.V(5).Infof("put insert before: %v, %v, %v", elem, tp.Timestamp, tp.Value)
+			ts.buffer.InsertBefore(newTPC, elem)
+			return nil
+		}
+	}
+	glog.V(5).Infof("put pushback: %v, %v", tp.Timestamp, tp.Value)
+	ts.buffer.PushBack(newTPC)
+	return nil
+}
+
+func (ts *cmaStore) Get(start, end time.Time) []TimePoint {
+	zeroTime := time.Time{}
+	ts.rwLock.RLock()
+	defer ts.rwLock.RUnlock()
+	if ts.buffer.Len() == 0 {
+		return nil
+	}
+	result := []TimePoint{}
+	for elem := ts.buffer.Front(); elem != nil; elem = elem.Next() {
+		tpc := elem.Value.(tpContainer)
+		entry := tpc.TimePoint
+
+		// Skip entries until the first one after start
+		if (start != zeroTime) && entry.Timestamp.Before(start) {
+			continue
+		}
+		// Add all entries whose timestamp is not after end.
+		if (end == time.Time{}) || !entry.Timestamp.After(end) {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+func (ts *cmaStore) Delete(start, end time.Time) error {
+	ts.rwLock.Lock()
+	defer ts.rwLock.Unlock()
+	if ts.buffer.Len() == 0 {
+		return nil
+	}
+	if (end != time.Time{}) && !end.After(start) {
+		return fmt.Errorf("end time %v is not after start time %v", end, start)
+	}
+	// Assuming that deletes will happen more frequently for older data.
+	elem := ts.buffer.Back()
+	for elem != nil {
+		tpc := elem.Value.(tpContainer)
+		if (end != time.Time{}) && tpc.Timestamp.After(end) {
+			// If we have reached an entry which is more recent than 'end' stop iterating.
+			break
+		}
+		oldElem := elem
+		elem = elem.Prev()
+
+		// Skip entries before the start time.
+		if !tpc.Timestamp.Before(start) {
+			ts.buffer.Remove(oldElem)
+		}
+	}
+	return nil
+}
+
+func NewCMAStore() TimeStore {
+	return &cmaStore{
+		buffer: list.New(),
+	}
+}

--- a/store/cma_store.go
+++ b/store/cma_store.go
@@ -93,7 +93,6 @@ func (ts *cmaStore) Get(start, end time.Time) []TimePoint {
 	for elem := ts.buffer.Front(); elem != nil; elem = elem.Next() {
 		tpc := elem.Value.(tpContainer)
 		entry := tpc.TimePoint
-
 		// Skip entries until the first one after start
 		if (start != zeroTime) && entry.Timestamp.Before(start) {
 			continue

--- a/store/cma_store_test.go
+++ b/store/cma_store_test.go
@@ -1,0 +1,138 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCMAInit(t *testing.T) {
+	store := NewCMAStore()
+	data := store.Get(time.Now().Add(-time.Minute), time.Now())
+	assert.Empty(t, len(data), time.Now())
+}
+
+func TestCMANilInsert(t *testing.T) {
+	store := NewCMAStore()
+	assert.Error(t, store.Put(TimePoint{time.Now(), nil}))
+}
+
+func TestCMAInsertNormal(t *testing.T) {
+	store := NewCMAStore()
+	now := time.Now()
+	assert := assert.New(t)
+	assert.NoError(store.Put(TimePoint{now, uint64(2)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-time.Second), uint64(1)}))
+	assert.NoError(store.Put(TimePoint{now.Add(time.Second), uint64(3)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-2 * time.Second), uint64(0)}))
+	actual := store.Get(time.Time{}, now)
+	require.Len(t, actual, 3)
+	actual = store.Get(time.Time{}, time.Time{})
+	require.Len(t, actual, 4)
+}
+
+func TestCMAInsertTime(t *testing.T) {
+	zeroTime := time.Time{}
+	store := NewCMAStore()
+	now := time.Now()
+	assert := assert.New(t)
+
+	// Errors
+	assert.Error(store.Put(TimePoint{zeroTime, uint64(2)}))
+	assert.Error(store.Put(TimePoint{zeroTime, nil}))
+
+	assert.NoError(store.Put(TimePoint{now, uint64(2)}))
+	assert.NoError(store.Put(TimePoint{now, uint64(6)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(20)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(10)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(1000)}))
+
+	// Get Invocation with values 2 and 4
+	actual := store.Get(zeroTime, now)
+	fmt.Println(actual)
+	require.Len(t, actual, 1)
+	assert.Equal(actual[0].Value, uint64(4))
+
+	// Get Invocation with values 0, 20, 10 and 1000
+	actual = store.Get(zeroTime, zeroTime)
+	require.Len(t, actual, 2)
+	assert.Equal(actual[0].Value, uint64(257)) // 257.5 rounded down
+	assert.Equal(actual[1].Value, uint64(4))
+
+	// Get correct averages after new puts
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-2 * time.Hour), uint64(999)}))
+	actual = store.Get(zeroTime, zeroTime)
+	require.Len(t, actual, 3)
+	assert.Equal(actual[0].Value, uint64(126)) // 128.75 approximation
+	assert.Equal(actual[1].Value, uint64(4))
+	assert.Equal(actual[2].Value, uint64(999))
+
+	// Get up until a point
+	assert.NoError(store.Put(TimePoint{now.Add(-time.Hour), uint64(30)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-time.Hour), uint64(40)}))
+	actual = store.Get(zeroTime, now.Add(-time.Hour))
+	require.Len(t, actual, 2)
+	assert.Equal(actual[0].Value, uint64(35))
+	assert.Equal(actual[1].Value, uint64(999))
+}
+
+func TestCMADelete(t *testing.T) {
+	zeroTime := time.Time{}
+	store := NewCMAStore()
+	now := time.Now()
+	assert := assert.New(t)
+
+	// Invocation with empty buffer
+	assert.NoError(store.Delete(now, now.Add(time.Minute)))
+
+	assert.NoError(store.Put(TimePoint{now, uint64(2)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-time.Second), uint64(1)}))
+	assert.NoError(store.Put(TimePoint{now.Add(-2 * time.Second), uint64(0)}))
+	assert.NoError(store.Put(TimePoint{now.Add(time.Second), uint64(3)}))
+
+	// Normal Invocation
+	assert.NoError(store.Delete(now.Add(-time.Second), now))
+	actual := store.Get(now.Add(-time.Second), zeroTime)
+	require.Len(t, actual, 1)
+	assert.Equal(uint64(3), actual[0].Value.(uint64))
+	assert.NoError(store.Delete(zeroTime, zeroTime))
+	assert.Empty(store.Get(zeroTime, zeroTime))
+
+	// Invocation with no affected data
+	assert.NoError(store.Put(TimePoint{now, uint64(2)}))
+	assert.NoError(store.Delete(zeroTime, now.Add(-time.Minute)))
+	actual = store.Get(zeroTime, zeroTime)
+	assert.Len(actual, 1)
+	assert.Equal(actual[0].Value, uint64(2))
+
+	// Invocation with start time
+	assert.NoError(store.Delete(now.Add(2*time.Minute), zeroTime))
+	actual = store.Get(zeroTime, zeroTime)
+	assert.Len(actual, 1)
+	assert.Equal(actual[0].Value, uint64(2))
+
+	// Invocation with error (start after end)
+	assert.Error(store.Delete(now, now.Add(-time.Minute)))
+}


### PR DESCRIPTION
Part 6 of #342 
IMPORTANT: depends on #378

This PR includes a full implementation of metric aggregation (summation) throughout the cluster structure.

New realCluster methods:
aggregationStep: performs full aggregation of all InfoTypes under the same lock
aggregateNodeMetrics: sums Node metrics to generate Cluster metrics
aggregateNamespaceMetrics: sums Pod metrics to generate Namespace metrics
aggregatePodMetrics: sums Container metrics to generate Pod metrics
aggregateMetrics: populates an InfoType by summing values from an []*InfoType

New utility functions:
addTimePoints: adds the values of two TimePoints, returns a new TimePoint
popTPSlice: pops the first element of a []TimePoint
addMatchingTimeseries: adds two []TimePoint with matching timestamps, returns a new []TImePoint

All methods that are not at 100% coverage contain internal error handling branches.

cc @vmarmol @vishh @rjnagal