### PR TITLE
add CA certs to the docker image

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -4,5 +4,8 @@ MAINTAINER vishnuk@google.com
 # cAdvisor discovery via external files.
 VOLUME /var/run/heapster/hosts
 
+RUN opkg-install ca-certificates
+RUN for cert in `ls -1 /etc/ssl/certs/*.crt | grep -v /etc/ssl/certs/ca-certificates.crt`; do cat "$cert" >> /etc/ssl/certs/ca-certificates.crt; done
+
 ADD heapster /heapster
 ENTRYPOINT ["/heapster"]


### PR DESCRIPTION
fixes #381. Although we fixed this in kubernetes with a config change to the controller.json, we shouldn't rely on a host directory in the long term. CA crts we need should be embedded in the image. cc @piosz @vishh 