### PR TITLE
Migrating to Kubernets API v1

### DIFF
--- a/deploy/kube-config/google/heapster-service.json
+++ b/deploy/kube-config/google/heapster-service.json
@@ -1,6 +1,6 @@
 {
   "kind": "Service",
-  "apiVersion": "v1beta3",
+  "apiVersion": "v1",
   "metadata": {
     "name": "monitoring-heapster",
     "labels": {

--- a/deploy/kube-config/influxdb/grafana-service.json
+++ b/deploy/kube-config/influxdb/grafana-service.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1beta3",
+  "apiVersion": "v1",
   "kind": "Service",
   "metadata": {
     "labels": {

--- a/deploy/kube-config/influxdb/heapster-service.json
+++ b/deploy/kube-config/influxdb/heapster-service.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1beta3",
+  "apiVersion": "v1",
   "kind": "Service",
   "metadata": {
     "labels": {

--- a/deploy/kube-config/influxdb/influxdb-grafana-controller.json
+++ b/deploy/kube-config/influxdb/influxdb-grafana-controller.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1beta3",
+  "apiVersion": "v1",
   "kind": "ReplicationController",
   "metadata": {
     "labels": {
@@ -38,7 +38,7 @@
             "env": [
               {
                 "name": "INFLUXDB_EXTERNAL_URL",
-                "value": "/api/v1beta3/proxy/namespaces/default/services/monitoring-grafana/db/"
+                "value": "/api/v1/proxy/namespaces/default/services/monitoring-grafana/db/"
               },
               {
                 "name": "INFLUXDB_HOST",

--- a/deploy/kube-config/influxdb/influxdb-service.json
+++ b/deploy/kube-config/influxdb/influxdb-service.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1beta3",
+  "apiVersion": "v1",
   "kind": "Service",
   "metadata": {
     "labels": {

--- a/deploy/kube-config/influxdb/influxdb-ui-service.json
+++ b/deploy/kube-config/influxdb/influxdb-ui-service.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1beta3",
+  "apiVersion": "v1",
   "kind": "Service",
   "metadata": {
     "labels": null,

--- a/deploy/kube-config/standalone/heapster-service.json
+++ b/deploy/kube-config/standalone/heapster-service.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1beta3",
+  "apiVersion": "v1",
   "kind": "Service",
   "metadata": {
     "labels": {

--- a/docs/influxdb.md
+++ b/docs/influxdb.md
@@ -10,7 +10,7 @@ _Warning: Virtual machines need to have at least 2 cores for InfluxDB to perform
 $ kubectl.sh create -f deploy/kube-config/influxdb/
 ```
 
-Grafana will be accessible at `https://<masterIP>/api/v1beta3/proxy/namespaces/default/services/monitoring-grafana/`. Use the master auth to access Grafana.
+Grafana will be accessible at `https://<masterIP>/api/v1/proxy/namespaces/default/services/monitoring-grafana/`. Use the master auth to access Grafana.
 
 ## Production setup for InfluxDB and Grafana
 

--- a/docs/source-configuration.md
+++ b/docs/source-configuration.md
@@ -34,7 +34,7 @@ like this:
 
 ```
 cat <EOF | kubectl create -f -
-apiVersion: v1beta3
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: heapster
@@ -44,7 +44,7 @@ EOF
 This will generate a token on the API server. You will then need to reference the service account in your Heapster pod spec like this:
 
 ```
-apiVersion: "v1beta3"
+apiVersion: "v1"
 kind: "ReplicationController"
 metadata:
   labels:

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	kclientcmd "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	kclientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
@@ -188,7 +188,7 @@ func getKubeClient() (string, *kclient.Client, error) {
 		*c,
 		&kclientcmd.ConfigOverrides{
 			ClusterInfo: kclientcmdapi.Cluster{
-				APIVersion: "v1beta3",
+				APIVersion: "v1",
 			},
 		}).ClientConfig()
 	if err != nil {
@@ -317,7 +317,7 @@ func (self *realKubeFramework) loadObject(filePath string) (runtime.Object, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to read object: %v", err)
 	}
-	return v1beta3.Codec.Decode(data)
+	return v1.Codec.Decode(data)
 }
 
 func (self *realKubeFramework) ParseRC(filePath string) (*api.ReplicationController, error) {

--- a/sources/kube_factory.go
+++ b/sources/kube_factory.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	defaultApiVersion         = "v1"
+	APIVersion = "v1"
+
 	defaultInsecure           = false
 	defaultKubeletPort        = 10255
 	defaultKubeletHttps       = false
@@ -48,7 +49,7 @@ func init() {
 func getConfigOverrides(uri string, options map[string][]string) (*kubeClientCmd.ConfigOverrides, error) {
 	kubeConfigOverride := kubeClientCmd.ConfigOverrides{
 		ClusterInfo: kubeClientCmdApi.Cluster{
-			APIVersion: defaultApiVersion,
+			APIVersion: APIVersion,
 		},
 	}
 	if uri != "" {
@@ -82,6 +83,11 @@ func CreateKubeSources(uri string, options map[string][]string) ([]api.Source, e
 		err        error
 	)
 
+	configOverrides, err := getConfigOverrides(uri, options)
+	if err != nil {
+		return nil, err
+	}
+
 	inClusterConfig := defaultInClusterConfig
 	if len(options["inClusterConfig"]) > 0 {
 		inClusterConfig, err = strconv.ParseBool(options["inClusterConfig"][0])
@@ -95,12 +101,9 @@ func CreateKubeSources(uri string, options map[string][]string) ([]api.Source, e
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		configOverrides, err := getConfigOverrides(uri, options)
-		if err != nil {
-			return nil, err
-		}
 
+		kubeConfig.Version = configOverrides.ClusterInfo.APIVersion
+	} else {
 		authFile := ""
 		if len(options["auth"]) > 0 {
 			authFile = options["auth"][0]

--- a/sources/pods.go
+++ b/sources/pods.go
@@ -102,7 +102,7 @@ func (self *realPodsApi) parseAllPods(podNodePairs []podNodePair) []api.Pod {
 func (self *realPodsApi) getNodeSelector(nodeList *nodes.NodeList) (labels.Selector, error) {
 	nodeLabels := []string{}
 	for host := range nodeList.Items {
-		nodeLabels = append(nodeLabels, fmt.Sprintf("spec.host==%s", host))
+		nodeLabels = append(nodeLabels, fmt.Sprintf("spec.nodeName==%s", host))
 	}
 	glog.V(2).Infof("using labels %v to find pods", nodeLabels)
 	return labels.Parse(strings.Join(nodeLabels, ","))
@@ -155,7 +155,7 @@ const resyncPeriod = time.Minute
 func newPodsApi(client *kclient.Client) podsApi {
 	// Extend the selector to include specific nodes to monitor
 	// or provide an API to update the nodes to monitor.
-	selector, err := kSelector.ParseSelector("spec.host!=")
+	selector, err := kSelector.ParseSelector("spec.nodeName!=")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Kubernetes is going to stop exposing the v1beta3 API by default, so this need to switch to the new version.

See https://github.com/GoogleCloudPlatform/kubernetes/issues/10755