### PR TITLE
[Schema 6] Metric Aggregation

### DIFF
--- a/schema/aggregation.go
+++ b/schema/aggregation.go
@@ -1,0 +1,214 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/heapster/store"
+)
+
+// aggregationStep performs a Metric Aggregation step on the cluster.
+// The Metrics fields of all Namespaces, Pods and the Cluster are populated,
+// by Timeseries summation of the respective Metrics fields.
+// aggregationStep should be called after new data is present in the cluster,
+// but before the cluster timestamp is updated.
+func (rc *realCluster) aggregationStep() error {
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+
+	// Perform Node Metric Aggregation
+	node_c := make(chan error)
+	go rc.aggregateNodeMetrics(node_c)
+
+	// Initiate bottom-up aggregation for Kubernetes stats
+	kube_c := make(chan error)
+	go rc.aggregateKubeMetrics(kube_c)
+
+	errs := make([]error, 2)
+	errs[0] = <-node_c
+	errs[1] = <-kube_c
+
+	if errs[0] != nil {
+		return errs[0]
+	}
+	if errs[1] != nil {
+		return errs[1]
+	}
+
+	return nil
+}
+
+// aggregateNodeMetrics populates the Cluster.InfoType.Metrics field by adding up all node metrics.
+// Assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) aggregateNodeMetrics(c chan error) {
+	if len(rc.Nodes) == 0 {
+		// Fail silently if the cluster has no nodes
+		c <- nil
+		return
+	}
+
+	sources := []*InfoType{}
+	for _, node := range rc.Nodes {
+		sources = append(sources, &(node.InfoType))
+	}
+	c <- rc.aggregateMetrics(&rc.ClusterInfo.InfoType, sources)
+}
+
+// aggregateKubeMetrics initiates depth-first aggregation of Kubernetes metrics.
+// Assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) aggregateKubeMetrics(c chan error) {
+	if len(rc.Namespaces) == 0 {
+		// Fail silently if the cluster has no namespaces
+		c <- nil
+		return
+	}
+
+	// Perform aggregation for all the namespaces
+	chans := make([]chan error, 0)
+	for _, namespace := range rc.Namespaces {
+		chans = append(chans, make(chan error))
+		go rc.aggregateNamespaceMetrics(namespace, chans[len(chans)-1])
+	}
+
+	errs := make([]error, len(chans))
+	for _, channel := range chans {
+		errs = append(errs, <-channel)
+	}
+
+	for _, err := range errs {
+		if err != nil {
+			c <- err
+			return
+		}
+	}
+
+	c <- nil
+}
+
+// aggregateNamespaceMetrics populates a NamespaceInfo.Metrics field by aggregating all PodInfo.
+// Assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) aggregateNamespaceMetrics(namespace *NamespaceInfo, c chan error) {
+	if namespace == nil {
+		c <- fmt.Errorf("nil Namespace pointer passed for aggregation")
+		return
+	}
+	if len(namespace.Pods) == 0 {
+		// Fail silently if the namespace has no pods
+		c <- nil
+		return
+	}
+
+	// Perform aggregation on all the Pods
+	chans := make([]chan error, 0)
+	for _, pod := range namespace.Pods {
+		chans = append(chans, make(chan error))
+		go rc.aggregatePodMetrics(pod, chans[len(chans)-1])
+	}
+
+	errs := make([]error, len(chans))
+	for _, channel := range chans {
+		errs = append(errs, <-channel)
+	}
+
+	for _, err := range errs {
+		if err != nil {
+			c <- err
+			return
+		}
+	}
+
+	// Collect the Pod InfoTypes after aggregation is complete
+	sources := []*InfoType{}
+	for _, pod := range namespace.Pods {
+		sources = append(sources, &(pod.InfoType))
+	}
+	c <- rc.aggregateMetrics(&namespace.InfoType, sources)
+}
+
+// aggregatePodMetrics populates a PodInfo.Metrics field by aggregating all ContainerInfo.
+// Assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) aggregatePodMetrics(pod *PodInfo, c chan error) {
+	if pod == nil {
+		c <- fmt.Errorf("nil Pod pointer passed for aggregation")
+		return
+	}
+	if len(pod.Containers) == 0 {
+		// Fail silently if the pod has no containers
+		c <- nil
+		return
+	}
+
+	// Collect the Container InfoTypes
+	sources := []*InfoType{}
+	for _, container := range pod.Containers {
+		sources = append(sources, &(container.InfoType))
+	}
+	c <- rc.aggregateMetrics(&pod.InfoType, sources)
+}
+
+// aggregateMetrics populates an InfoType by adding metrics across a slice of InfoTypes.
+// Only metrics taken after the cluster timestamp are affected.
+// Assumes an appropriate lock is already taken by the caller.
+func (rc *realCluster) aggregateMetrics(target *InfoType, sources []*InfoType) error {
+	zeroTime := time.Time{}
+
+	if target == nil {
+		return fmt.Errorf("nil InfoType pointer provided as aggregation target")
+	}
+	if len(sources) == 0 {
+		return fmt.Errorf("empty sources slice provided")
+	}
+	for _, source := range sources {
+		if source == nil {
+			return fmt.Errorf("nil InfoType pointer provided as an aggregation source")
+		}
+		if source == target {
+			return fmt.Errorf("target InfoType pointer is provided as a source")
+		}
+	}
+
+	// Create a map of []TimePoint as a timeseries accumulator per metric
+	newMetrics := make(map[string][]store.TimePoint)
+
+	// Reduce the sources slice with timeseries addition for each metric
+	for _, info := range sources {
+		for key, ts := range info.Metrics {
+			_, ok := newMetrics[key]
+			if !ok {
+				// Metric does not exist on target map, create a new timeseries
+				newMetrics[key] = []store.TimePoint{}
+			}
+			// Perform timeseries addition between the accumulator and the current source
+			sourceTS := (*ts).Get(rc.timestamp, zeroTime)
+			newMetrics[key] = addMatchingTimeseries(newMetrics[key], sourceTS)
+		}
+	}
+
+	// Put all the new values in the TimeStores under target
+	for key, tpSlice := range newMetrics {
+		_, ok := target.Metrics[key]
+		if !ok {
+			// Metric does not exist on target InfoType, create TimeStore
+			newTS := rc.tsConstructor()
+			target.Metrics[key] = &newTS
+		}
+		for _, tp := range tpSlice {
+			(*target.Metrics[key]).Put(tp)
+		}
+	}
+	return nil
+}

--- a/schema/aggregation_test.go
+++ b/schema/aggregation_test.go
@@ -1,0 +1,205 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/GoogleCloudPlatform/heapster/store"
+)
+
+// TestAggregateNodeMetricsEmpty tests the empty flow of aggregateNodeMetrics.
+// The normal flow is tested through TestUpdate.
+func TestAggregateNodeMetricsEmpty(t *testing.T) {
+	var (
+		cluster = newRealCluster(newTimeStore, time.Minute)
+		c       = make(chan error)
+		assert  = assert.New(t)
+	)
+
+	// Invocation with empty cluster
+	go cluster.aggregateNodeMetrics(c)
+	assert.NoError(<-c)
+	assert.Empty(cluster.Nodes)
+	assert.Empty(cluster.Metrics)
+}
+
+// TestAggregateKubeMetricsError tests the error flows of aggregateKubeMetrics.
+// The normal flow is tested through TestUpdate.
+func TestAggregateKubeMetricsEmpty(t *testing.T) {
+	var (
+		cluster = newRealCluster(newTimeStore, time.Minute)
+		c       = make(chan error)
+		assert  = assert.New(t)
+	)
+
+	// Invocation with empty cluster
+	go cluster.aggregateKubeMetrics(c)
+	assert.NoError(<-c)
+	assert.Empty(cluster.Namespaces)
+
+	// Error propagation from aggregateNamespaceMetrics
+	cluster.Namespaces["default"] = nil
+	go cluster.aggregateKubeMetrics(c)
+	assert.Error(<-c)
+	assert.NotEmpty(cluster.Namespaces)
+}
+
+// TestAggregateNamespaceMetrics tests the error flows of aggregateNamespaceMetrics.
+// The normal flow is tested through TestUpdate.
+func TestAggregateNamespaceMetricsError(t *testing.T) {
+	var (
+		cluster = newRealCluster(newTimeStore, time.Minute)
+		c       = make(chan error)
+		assert  = assert.New(t)
+	)
+
+	// Invocation with nil namespace
+	go cluster.aggregateNamespaceMetrics(nil, c)
+	assert.Error(<-c)
+	assert.Empty(cluster.Namespaces)
+
+	// Invocation for a namespace with no pods
+	ns := cluster.addNamespace("default")
+	go cluster.aggregateNamespaceMetrics(ns, c)
+	assert.NoError(<-c)
+	assert.Len(ns.Pods, 0)
+
+	// Error propagation from aggregatePodMetrics
+	ns.Pods["pod1"] = nil
+	go cluster.aggregateNamespaceMetrics(ns, c)
+	assert.Error(<-c)
+}
+
+// TestAggregatePodMetricsError tests the error flows of aggregatePodMetrics.
+// The normal flow is tested through TestUpdate.
+func TestAggregatePodMetricsError(t *testing.T) {
+	var (
+		cluster = newRealCluster(newTimeStore, time.Minute)
+		c       = make(chan error)
+		assert  = assert.New(t)
+	)
+	ns := cluster.addNamespace("default")
+	node := cluster.addNode("newnode")
+	pod := cluster.addPod("pod1", "uid111", ns, node)
+
+	// Invocation with nil pod
+	go cluster.aggregatePodMetrics(nil, c)
+	assert.Error(<-c)
+
+	// Invocation with empty pod
+	go cluster.aggregatePodMetrics(pod, c)
+	assert.NoError(<-c)
+
+	// Invocation with a normal pod
+	addContainerToMap("new_container", pod.Containers)
+	addContainerToMap("new_container2", pod.Containers)
+	go cluster.aggregatePodMetrics(pod, c)
+	assert.NoError(<-c)
+}
+
+// TestAggregateMetricsError tests the error flows of aggregateMetrics.
+func TestAggregateMetricsError(t *testing.T) {
+	var (
+		cluster    = newRealCluster(newTimeStore, time.Minute)
+		targetInfo = InfoType{
+			Metrics: make(map[string]*store.TimeStore),
+			Labels:  make(map[string]string),
+		}
+		srcInfo = InfoType{
+			Metrics: make(map[string]*store.TimeStore),
+			Labels:  make(map[string]string),
+		}
+		assert = assert.New(t)
+	)
+
+	// Invocation with nil first argument
+	sources := []*InfoType{&srcInfo}
+	assert.Error(cluster.aggregateMetrics(nil, sources))
+
+	// Invocation with empty second argument
+	sources = []*InfoType{}
+	assert.Error(cluster.aggregateMetrics(&targetInfo, sources))
+
+	// Invocation with a nil element in the second argument
+	sources = []*InfoType{&srcInfo, nil}
+	assert.Error(cluster.aggregateMetrics(&targetInfo, sources))
+
+	// Invocation with the target being also part of sources
+	sources = []*InfoType{&srcInfo, &targetInfo}
+	assert.Error(cluster.aggregateMetrics(&targetInfo, sources))
+}
+
+// TestAggregateMetricsNormal tests the normal flows of aggregateMetrics.
+func TestAggregateMetricsNormal(t *testing.T) {
+	var (
+		cluster    = newRealCluster(newTimeStore, time.Minute)
+		targetInfo = InfoType{
+			Metrics: make(map[string]*store.TimeStore),
+			Labels:  make(map[string]string),
+		}
+		srcInfo1 = InfoType{
+			Metrics: make(map[string]*store.TimeStore),
+			Labels:  make(map[string]string),
+		}
+		srcInfo2 = InfoType{
+			Metrics: make(map[string]*store.TimeStore),
+			Labels:  make(map[string]string),
+		}
+		now    = time.Now().Round(time.Minute)
+		assert = assert.New(t)
+	)
+
+	newTS := newTimeStore()
+	newTS.Put(store.TimePoint{
+		Timestamp: now,
+		Value:     uint64(5000),
+	})
+	newTS.Put(store.TimePoint{
+		Timestamp: now.Add(time.Hour),
+		Value:     uint64(3000),
+	})
+	newTS2 := newTimeStore()
+	newTS2.Put(store.TimePoint{
+		Timestamp: now,
+		Value:     uint64(2000),
+	})
+	newTS2.Put(store.TimePoint{
+		Timestamp: now.Add(time.Hour),
+		Value:     uint64(3500),
+	})
+	newTS2.Put(store.TimePoint{
+		Timestamp: now.Add(2 * time.Hour),
+		Value:     uint64(9000),
+	})
+
+	srcInfo1.Metrics[memUsage] = &newTS
+	srcInfo2.Metrics[memUsage] = &newTS2
+	sources := []*InfoType{&srcInfo1, &srcInfo2}
+
+	// Normal Invocation
+	cluster.aggregateMetrics(&targetInfo, sources)
+
+	assert.NotNil(targetInfo.Metrics[memUsage])
+	targetMemTS := *(targetInfo.Metrics[memUsage])
+	res := targetMemTS.Get(time.Time{}, time.Time{})
+	assert.Len(res, 3)
+	assert.Equal(res[0].Value, uint64(9000))
+	assert.Equal(res[1].Value, uint64(6500))
+	assert.Equal(res[2].Value, uint64(7000))
+}

--- a/schema/impl.go
+++ b/schema/impl.go
@@ -24,13 +24,14 @@ import (
 	"github.com/GoogleCloudPlatform/heapster/store"
 )
 
-// NewCluster returns a new Cluster, given a TimeStore constructor function.
-func NewCluster(tsConstructor func() store.TimeStore) Cluster {
-	return newRealCluster(tsConstructor)
+// NewCluster returns a new Cluster.
+// Receives a TimeStore constructor function and a Duration resolution for stored data.
+func NewCluster(tsConstructor func() store.TimeStore, resolution time.Duration) Cluster {
+	return newRealCluster(tsConstructor, resolution)
 }
 
-// newRealCluster returns a realCluster, given a TimeStore constructor.
-func newRealCluster(tsConstructor func() store.TimeStore) *realCluster {
+// newRealCluster returns a realCluster, given a TimeStore constructor and a Duration resolution.
+func newRealCluster(tsConstructor func() store.TimeStore, resolution time.Duration) *realCluster {
 	cinfo := ClusterInfo{
 		InfoType:   newInfoType(nil, nil),
 		Namespaces: make(map[string]*NamespaceInfo),
@@ -40,61 +41,9 @@ func newRealCluster(tsConstructor func() store.TimeStore) *realCluster {
 		timestamp:     time.Time{},
 		ClusterInfo:   cinfo,
 		tsConstructor: tsConstructor,
+		resolution:    resolution,
 	}
 	return cluster
-}
-
-// GetAllClusterData returns a pointer to the ClusterInfo, along with all of its metrics.
-// GetAllClusterData also returns the latest cluster timestamp, for reuse in GetNew* methods.
-func (rc *realCluster) GetAllClusterData() (*ClusterInfo, time.Time, error) {
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-	return &rc.ClusterInfo, rc.timestamp, nil
-}
-
-// GetAllNodeData finds a node, given a hostname (internal to the cluster).
-// GetAllNodeData returns a corresponding NodeInfo object, along with all of its metrics.
-// GetAllNodeData also returns the latest cluster timestamp, for reuse in GetNew* methods.
-func (rc *realCluster) GetAllNodeData(hostname string) (*NodeInfo, time.Time, error) {
-	// TODO(alex): should return a deep copy instead of a pointer
-	var zeroTime time.Time
-
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	res, ok := rc.Nodes[hostname]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("unable to find node with hostname: %s", hostname)
-	}
-
-	return res, rc.timestamp, nil
-}
-
-// GetAllPodData finds a pod, given a namespace string and a pod name string.
-// GetAllPodData returns a pointer to a PodInfo object, along with all of its metrics.
-// GetAllPodData also returns the latest cluster timestamp, for reuse in GetNew* methods.
-func (rc *realCluster) GetAllPodData(namespace string, pod_name string) (*PodInfo, time.Time, error) {
-	// TODO(alex): should return a deep copy instead of a pointer
-	var zeroTime time.Time
-
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	if len(rc.Namespaces) == 0 {
-		return nil, zeroTime, fmt.Errorf("unable to find pod: no namespaces in cluster")
-	}
-
-	ns, ok := rc.Namespaces[namespace]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("unable to find namespace with name: %s", namespace)
-	}
-
-	pod, ok := ns.Pods[pod_name]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("unable to find pod with name: %s", pod_name)
-	}
-
-	return pod, rc.timestamp, nil
 }
 
 // updateTime updates the Cluster timestamp to the specified time.
@@ -196,8 +145,8 @@ func (rc *realCluster) addPod(pod_name string, pod_uid string, namespace *Namesp
 }
 
 // updateInfoType updates the metrics of an InfoType from a ContainerElement.
-// updateInfoType returns the latest timestamp in the resulting TimeStore
-// updateInfoType does not fail if a single ContainerMetricElement cannot be parsed
+// updateInfoType returns the latest timestamp in the resulting TimeStore.
+// updateInfoType does not fail if a single ContainerMetricElement cannot be parsed.
 func (rc *realCluster) updateInfoType(info *InfoType, ce *cache.ContainerElement) (time.Time, error) {
 	var latest_time time.Time
 
@@ -220,7 +169,8 @@ func (rc *realCluster) updateInfoType(info *InfoType, ce *cache.ContainerElement
 }
 
 // addMetricToMap adds a new metric (time-value pair) to a map of TimeStores.
-// addMetricToMap accepts as arguments the metric name, timestamp, value and the TimeStore map
+// addMetricToMap accepts as arguments the metric name, timestamp, value and the TimeStore map.
+// The timestamp argument needs to be already rounded to the cluster resolution.
 func (rc *realCluster) addMetricToMap(metric string, timestamp time.Time, value uint64, dict map[string]*store.TimeStore) error {
 	point := store.TimePoint{
 		Timestamp: timestamp,
@@ -243,7 +193,7 @@ func (rc *realCluster) addMetricToMap(metric string, timestamp time.Time, value 
 	return nil
 }
 
-// parseMetric populates a map[string]*TimeStore from a ContainerMetricElement
+// parseMetric populates a map[string]*TimeStore from a ContainerMetricElement.
 // parseMetric returns the ContainerMetricElement timestamp, iff successful.
 func (rc *realCluster) parseMetric(cme *cache.ContainerMetricElement, dict map[string]*store.TimeStore) (time.Time, error) {
 	zeroTime := time.Time{}
@@ -254,7 +204,10 @@ func (rc *realCluster) parseMetric(cme *cache.ContainerMetricElement, dict map[s
 		return zeroTime, fmt.Errorf("cannot populate nil map")
 	}
 
-	timestamp := cme.Stats.Timestamp
+	// Round the timestamp to the nearest resolution
+	timestamp := cme.Stats.Timestamp.Round(rc.resolution)
+
+	// TODO(alex): refactor to avoid repetition
 	if cme.Spec.HasCpu {
 		// Add CPU Limit metric
 		cpu_limit := cme.Spec.Cpu.Limit
@@ -349,6 +302,9 @@ func (rc *realCluster) Update(c cache.Cache) error {
 		latest_time = latestTimestamp(latest_time, timestamp)
 	}
 
+	// Perform metrics aggregation
+	rc.aggregationStep()
+
 	// Update the Cluster timestamp to the latest time found in the new metrics
 	rc.updateTime(latest_time)
 
@@ -356,7 +312,7 @@ func (rc *realCluster) Update(c cache.Cache) error {
 	return nil
 }
 
-// updateNode updates Node-level information from a "machine"-tagged ContainerElement
+// updateNode updates Node-level information from a "machine"-tagged ContainerElement.
 func (rc *realCluster) updateNode(node_container *cache.ContainerElement) (time.Time, error) {
 	if node_container.Name != "machine" {
 		return time.Time{}, fmt.Errorf("Received node-level container with unexpected name: %s", node_container.Name)
@@ -371,7 +327,7 @@ func (rc *realCluster) updateNode(node_container *cache.ContainerElement) (time.
 	return result, err
 }
 
-// updatePod updates Pod-level information from a PodElement
+// updatePod updates Pod-level information from a PodElement.
 func (rc *realCluster) updatePod(pod *cache.PodElement) (time.Time, error) {
 	if pod == nil {
 		return time.Time{}, fmt.Errorf("nil PodElement provided to updatePod")
@@ -403,9 +359,9 @@ func (rc *realCluster) updatePod(pod *cache.PodElement) (time.Time, error) {
 	return latest_time, nil
 }
 
-// updatePodContainer updates a Pod's Container-level information from a ContainerElement
-// updatePodContainer receives a PodInfo pointer and a ContainerElement pointer
-// Assumes Cluster lock is already taken
+// updatePodContainer updates a Pod's Container-level information from a ContainerElement.
+// updatePodContainer receives a PodInfo pointer and a ContainerElement pointer.
+// Assumes Cluster lock is already taken.
 func (rc *realCluster) updatePodContainer(pod_info *PodInfo, ce *cache.ContainerElement) (time.Time, error) {
 	// Get Container pointer and update its InfoType
 	cinfo := addContainerToMap(ce.Name, pod_info.Containers)

--- a/schema/impl_test.go
+++ b/schema/impl_test.go
@@ -15,6 +15,7 @@
 package schema
 
 import (
+	"math/rand"
 	"strings"
 	"testing"
 	"time"
@@ -31,19 +32,19 @@ import (
 // newTimeStore creates a new GCStore and returns it as a TimeStore.
 // Meant to be passed to newRealCluster calls in all unit tests.
 func newTimeStore() store.TimeStore {
-	return store.NewGCStore(store.NewTimeStore(), time.Hour)
+	return store.NewGCStore(store.NewCMAStore(), 24*time.Hour)
 }
 
 // TestNewCluster tests the sanity of NewCluster
 func TestNewCluster(t *testing.T) {
-	cluster := NewCluster(newTimeStore)
+	cluster := NewCluster(newTimeStore, time.Minute)
 	assert.NotNil(t, cluster)
 }
 
 // TestAddNamespace tests all flows of addNamespace.
 func TestAddNamespace(t *testing.T) {
 	var (
-		cluster        = newRealCluster(newTimeStore)
+		cluster        = newRealCluster(newTimeStore, time.Minute)
 		namespace_name = "default"
 		assert         = assert.New(t)
 	)
@@ -65,7 +66,7 @@ func TestAddNamespace(t *testing.T) {
 // TestAddNode tests all flows of addNode.
 func TestAddNode(t *testing.T) {
 	var (
-		cluster  = newRealCluster(newTimeStore)
+		cluster  = newRealCluster(newTimeStore, time.Minute)
 		hostname = "kubernetes-minion-xkhz"
 		assert   = assert.New(t)
 	)
@@ -88,7 +89,7 @@ func TestAddNode(t *testing.T) {
 // TestAddPod tests all flows of addPod.
 func TestAddPod(t *testing.T) {
 	var (
-		cluster   = newRealCluster(newTimeStore)
+		cluster   = newRealCluster(newTimeStore, time.Minute)
 		pod_name  = "podname-xkhz"
 		pod_uid   = "123124-124124-124124124124"
 		namespace = cluster.addNamespace("default")
@@ -124,7 +125,7 @@ func TestAddPod(t *testing.T) {
 // TestUpdateTime tests the sanity of updateTime.
 func TestUpdateTime(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore)
+		cluster = newRealCluster(newTimeStore, time.Minute)
 		stamp   = time.Now()
 	)
 
@@ -140,51 +141,70 @@ func TestUpdateTime(t *testing.T) {
 // Tests the flow of AddMetricToMap where the metric name is present in the map
 func TestAddMetricToMapExistingKey(t *testing.T) {
 	var (
-		cluster                = newRealCluster(newTimeStore)
-		metrics                = make(map[string]*store.TimeStore)
-		new_metric_name string = "name_already_in_map"
-		value           uint64 = 1234567890
-		zeroTime               = time.Time{}
-		stamp                  = time.Now()
-		assert                 = assert.New(t)
+		cluster         = newRealCluster(newTimeStore, time.Minute)
+		metrics         = make(map[string]*store.TimeStore)
+		new_metric_name = "name_already_in_map"
+		value           = uint64(1234567890)
+		zeroTime        = time.Time{}
+		stamp           = time.Now().Round(time.Minute)
+		assert          = assert.New(t)
 	)
 
-	// Put a dummy metric in the map
-	new_tp := store.TimePoint{
-		Timestamp: stamp,
-		Value:     123,
-	}
-	ts := newTimeStore()
-	assert.NoError(ts.Put(new_tp))
-	metrics[new_metric_name] = &ts
-
-	// Fist Call: addMetricToMap for a new metric with the same name
+	// Fist Call: addMetricToMap for a new metric
 	assert.NoError(cluster.addMetricToMap(new_metric_name, stamp, value, metrics))
 
-	new_ts := *metrics[new_metric_name]
-	results := new_ts.Get(zeroTime, zeroTime)
-
-	// Expect both metrics to be available through Get
-	assert.Len(results, 2)
+	ts := *metrics[new_metric_name]
+	results := ts.Get(zeroTime, zeroTime)
+	assert.Len(results, 1)
 	assert.Equal(results[0].Timestamp, stamp)
-	assert.Equal(results[0].Value, 123)
-	assert.Equal(results[1].Timestamp, stamp)
-	assert.Equal(results[1].Value, value)
+	assert.Equal(results[0].Value, value)
 
-	// Second Call: addMetricToMap for an existing key, cause TimeStore failure
-	assert.Error(cluster.addMetricToMap(new_metric_name, zeroTime, value, metrics))
+	// Second Call: addMetricToMap for an existing key, same time
+	new_value := uint64(102)
+	assert.NoError(cluster.addMetricToMap(new_metric_name, stamp, new_value, metrics))
+
+	ts = *metrics[new_metric_name]
+	results = ts.Get(zeroTime, zeroTime)
+	assert.Len(results, 1)
+	assert.Equal(results[0].Timestamp, stamp)
+	assert.Equal(results[0].Value, uint64(617283996))
+
+	// Second Call: addMetricToMap for an existing key, new time
+	later_stamp := stamp.Add(2 * time.Hour)
+	assert.NoError(cluster.addMetricToMap(new_metric_name, later_stamp, new_value, metrics))
+
+	ts = *metrics[new_metric_name]
+	results = ts.Get(zeroTime, zeroTime)
+	assert.Len(results, 2)
+	assert.Equal(results[0].Timestamp, later_stamp)
+	assert.Equal(results[0].Value, uint64(102))
+	assert.Equal(results[1].Timestamp, stamp)
+	assert.Equal(results[1].Value, uint64(617283996))
+
+	// Third Call: addMetricToMap for an existing key, overwrites previous data
+	later_stamp = stamp.Add(48 * time.Hour)
+	assert.NoError(cluster.addMetricToMap(new_metric_name, later_stamp, new_value, metrics))
+
+	ts = *metrics[new_metric_name]
+	results = ts.Get(zeroTime, zeroTime)
+	assert.Len(results, 1)
+	assert.Equal(results[0].Timestamp, later_stamp)
+	assert.Equal(results[0].Value, uint64(102))
+
+	// Fourth Call: addMetricToMap for an existing key, cause TimeStore failure
+	assert.Error(cluster.addMetricToMap(new_metric_name, zeroTime, new_value, metrics))
 }
 
 // Tests the flow of AddMetricToMap where the metric name is not present in the map
 func TestAddMetricToMapNewKey(t *testing.T) {
 	var (
-		cluster                = newRealCluster(newTimeStore)
-		metrics                = make(map[string]*store.TimeStore)
-		new_metric_name        = "name_not_in_map"
-		stamp                  = time.Now()
-		zeroTime               = time.Time{}
-		value           uint64 = 1234567890
-		assert                 = assert.New(t)
+		cluster         = newRealCluster(newTimeStore, time.Minute)
+		metrics         = make(map[string]*store.TimeStore)
+		new_metric_name = "name_not_in_map"
+		stamp           = time.Now()
+		zeroTime        = time.Time{}
+		value           = uint64(1234567890)
+		assert          = assert.New(t)
 	)
 
 	// First Call: Add a new metric to the map
@@ -202,7 +222,7 @@ func TestAddMetricToMapNewKey(t *testing.T) {
 // TestParseMetricError tests the error flows of ParseMetric
 func TestParseMetricError(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore)
+		cluster = newRealCluster(newTimeStore, time.Minute)
 		assert  = assert.New(t)
 	)
 
@@ -221,23 +241,24 @@ func TestParseMetricError(t *testing.T) {
 // TestParseMetricNormal tests the normal flow of ParseMetric
 func TestParseMetricNormal(t *testing.T) {
 	var (
-		cluster    = newRealCluster(newTimeStore)
+		cluster    = newRealCluster(newTimeStore, time.Minute)
 		zeroTime   = time.Time{}
 		metrics    = make(map[string]*store.TimeStore)
 		normal_cme = cmeFactory()
 		assert     = assert.New(t)
 	)
+	rounded_stamp := normal_cme.Stats.Timestamp.Round(time.Minute)
 
 	// Normal Invocation with a regular CME
 	stamp, err := cluster.parseMetric(normal_cme, metrics)
 	assert.NoError(err)
-	assert.Equal(stamp, normal_cme.Stats.Timestamp)
+	assert.Equal(stamp, rounded_stamp)
 	for key, ts := range metrics {
 		actual_ts := *ts
 		pointSlice := actual_ts.Get(zeroTime, zeroTime)
 		assert.Len(pointSlice, 1)
 		metric := pointSlice[0]
-		assert.Equal(metric.Timestamp, normal_cme.Stats.Timestamp)
+		assert.Equal(metric.Timestamp, rounded_stamp)
 		switch key {
 		case "cpu/limit":
 			assert.Equal(metric.Value, normal_cme.Spec.Cpu.Limit)
@@ -265,7 +286,7 @@ func TestParseMetricNormal(t *testing.T) {
 // TestUpdateInfoTypeError Tests the error flows of updateInfoType.
 func TestUpdateInfoTypeError(t *testing.T) {
 	var (
-		cluster      = newRealCluster(newTimeStore)
+		cluster      = newRealCluster(newTimeStore, time.Minute)
 		new_infotype = newInfoType(nil, nil)
 		full_ce      = containerElementFactory(nil)
 		assert       = assert.New(t)
@@ -286,11 +307,10 @@ func TestUpdateInfoTypeError(t *testing.T) {
 // TestUpdateInfoTypeNormal tests the normal flows of UpdateInfoType.
 func TestUpdateInfoTypeNormal(t *testing.T) {
 	var (
-		cluster      = newRealCluster(newTimeStore)
+		cluster      = newRealCluster(newTimeStore, time.Minute)
 		new_cme      = cmeFactory()
 		empty_ce     = containerElementFactory([]*cache.ContainerMetricElement{})
 		nil_ce       = containerElementFactory([]*cache.ContainerMetricElement{new_cme, nil})
-		new_ce       = containerElementFactory([]*cache.ContainerMetricElement{new_cme})
 		new_infotype = newInfoType(nil, nil)
 		zeroTime     = time.Time{}
 		assert       = assert.New(t)
@@ -315,6 +335,9 @@ func TestUpdateInfoTypeNormal(t *testing.T) {
 
 	// Invocation with an empty InfoType argument
 	// The new ContainerElement adds one TimePoint to each of 7 Metrics
+	newer_cme := cmeFactory()
+	newer_cme.Stats.Timestamp = new_cme.Stats.Timestamp.Add(-time.Hour)
+	new_ce := containerElementFactory([]*cache.ContainerMetricElement{newer_cme})
 	stamp, err = cluster.updateInfoType(&new_infotype, new_ce)
 	assert.NoError(err)
 	assert.Empty(new_infotype.Labels)
@@ -342,7 +365,7 @@ func TestUpdateInfoTypeNormal(t *testing.T) {
 // TestUpdateFreeContainer tests the flow of updateFreeContainer
 func TestUpdateFreeContainer(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore)
+		cluster = newRealCluster(newTimeStore, time.Minute)
 		ce      = containerElementFactory(nil)
 		assert  = assert.New(t)
 	)
@@ -362,7 +385,7 @@ func TestUpdateFreeContainer(t *testing.T) {
 // TestUpdatePodContainer tests the flow of updatePodContainer
 func TestUpdatePodContainer(t *testing.T) {
 	var (
-		cluster   = newRealCluster(newTimeStore)
+		cluster   = newRealCluster(newTimeStore, time.Minute)
 		namespace = cluster.addNamespace("default")
 		node      = cluster.addNode("new_node_xyz")
 		pod_ptr   = cluster.addPod("new_pod", "1234-1245-235235", namespace, node)
@@ -380,7 +403,7 @@ func TestUpdatePodContainer(t *testing.T) {
 // TestUpdatePodNormal tests the normal flow of updatePod.
 func TestUpdatePodNormal(t *testing.T) {
 	var (
-		cluster  = newRealCluster(newTimeStore)
+		cluster  = newRealCluster(newTimeStore, time.Minute)
 		pod_elem = podElementFactory()
 		assert   = assert.New(t)
 	)
@@ -398,7 +421,7 @@ func TestUpdatePodNormal(t *testing.T) {
 // TestUpdatePodError tests the error flow of updatePod.
 func TestUpdatePodError(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore)
+		cluster = newRealCluster(newTimeStore, time.Minute)
 		assert  = assert.New(t)
 	)
 	// Invocation with a nil parameter
@@ -410,7 +433,7 @@ func TestUpdatePodError(t *testing.T) {
 // TestUpdateNodeInvalid tests the error flow of updateNode.
 func TestUpdateNodeInvalid(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore)
+		cluster = newRealCluster(newTimeStore, time.Minute)
 		ce      = containerElementFactory(nil)
 		assert  = assert.New(t)
 	)
@@ -424,7 +447,7 @@ func TestUpdateNodeInvalid(t *testing.T) {
 // TestUpdateNodeNormal tests the normal flow of updateNode.
 func TestUpdateNodeNormal(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore)
+		cluster = newRealCluster(newTimeStore, time.Minute)
 		ce      = containerElementFactory(nil)
 		assert  = assert.New(t)
 	)
@@ -437,20 +460,88 @@ func TestUpdateNodeNormal(t *testing.T) {
 	assert.NotEqual(stamp, time.Time{})
 }
 
-// TestUpdate tests the normal flow of Update.
+// TestUpdate tests the normal flows of Update.
+// TestUpdate performs consecutive calls to Update with both empty and non-empty caches
 func TestUpdate(t *testing.T) {
 	var (
-		cluster      = newRealCluster(newTimeStore)
+		cluster      = newRealCluster(newTimeStore, time.Minute)
 		source_cache = cacheFactory()
+		assert       = assert.New(t)
+		empty_cache  = cache.NewCache(24 * time.Hour)
 	)
+
+	// Invocation with empty cache
+	assert.NoError(cluster.Update(empty_cache))
+	assert.Empty(cluster.Nodes)
+	assert.Empty(cluster.Namespaces)
+	assert.Empty(cluster.Metrics)
+
 	// Invocation with regular parameters
-	assert.NoError(t, cluster.Update(source_cache))
+	assert.NoError(cluster.Update(source_cache))
 	verifyCacheFactoryCluster(&cluster.ClusterInfo, t)
+
+	// Assert Node Metric aggregation
+	assert.NotEmpty(cluster.Nodes)
+	assert.NotEmpty(cluster.Metrics)
+	assert.NotNil(cluster.Metrics[memWorking])
+	mem_work_ts := *(cluster.Metrics[memWorking])
+	actual := mem_work_ts.Get(time.Time{}, time.Time{})
+	assert.Len(actual, 1)
+	assert.Equal(actual[0].Value.(uint64), uint64(1204))
+
+	assert.NotNil(cluster.Metrics[memUsage])
+	mem_usage_ts := *(cluster.Metrics[memUsage])
+	actual = mem_usage_ts.Get(time.Time{}, time.Time{})
+	assert.Len(actual, 1)
+	assert.Equal(actual[0].Value.(uint64), uint64(10000))
+
+	// Assert Kubernetes Metric aggregation up to namespaces
+	ns := cluster.Namespaces["test"]
+	mem_work_ts = *(ns.Metrics[memWorking])
+	actual = mem_work_ts.Get(time.Time{}, time.Time{})
+	assert.Len(actual, 1)
+	assert.Equal(actual[0].Value.(uint64), uint64(1204))
+
+	// Invocation with no fresh data - expect no change in cluster
+	assert.NoError(cluster.Update(source_cache))
+	verifyCacheFactoryCluster(&cluster.ClusterInfo, t)
+
+	// Invocation with empty cache - expect no change in cluster
+	assert.NoError(cluster.Update(empty_cache))
+	verifyCacheFactoryCluster(&cluster.ClusterInfo, t)
+}
+
+// verifyCacheFactoryCluster performs assertions over a ClusterInfo structure,
+// based on the values and structure generated by cacheFactory.
+func verifyCacheFactoryCluster(clinfo *ClusterInfo, t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(clinfo.Nodes["hostname2"])
+	node2 := clinfo.Nodes["hostname2"]
+	assert.NotEmpty(node2.Metrics)
+	assert.Len(node2.FreeContainers, 1)
+	assert.NotNil(node2.FreeContainers["free_container1"])
+
+	assert.NotNil(clinfo.Nodes["hostname3"])
+	node3 := clinfo.Nodes["hostname3"]
+	assert.NotEmpty(node3.Metrics)
+
+	assert.NotNil(clinfo.Namespaces["test"])
+	namespace := clinfo.Namespaces["test"]
+
+	assert.NotNil(namespace.Pods)
+	pod1_ptr := namespace.Pods["pod1"]
+	assert.Equal(pod1_ptr, node2.Pods["pod1"])
+	assert.Len(pod1_ptr.Containers, 2)
+	pod2_ptr := namespace.Pods["pod2"]
+	assert.Equal(pod2_ptr, node3.Pods["pod2"])
+	assert.Len(pod2_ptr.Containers, 0)
 }
 
 // Factory Functions
 
 // cmeFactory generates a complete ContainerMetricElement with fuzzed data.
+// CMEs created by cmeFactory contain fuzzed data, aside from fixed memory usage and working set.
+// The timestamp of the CME is rouded to the current minute and offset by a random number of hours.
 func cmeFactory() *cache.ContainerMetricElement {
 	f := fuzz.New().NilChance(0).NumElements(1, 1)
 	containerSpec := cadvisor.ContainerSpec{
@@ -461,10 +552,23 @@ func cmeFactory() *cache.ContainerMetricElement {
 		HasFilesystem: true,
 		HasDiskIo:     true,
 	}
+	// Create a fuzzed ContainerStats struct
 	var containerStats cadvisor.ContainerStats
 	f.Fuzz(&containerStats)
-	containerStats.Timestamp = time.Now()
 
+	// Standardize timestamp to the current minute plus a random number of hours ([1, 10])
+	now_time := time.Now().Round(time.Minute)
+	new_time := now_time
+	for new_time == now_time {
+		new_time = now_time.Add(time.Duration(rand.Intn(10)) * time.Hour)
+	}
+	containerStats.Timestamp = new_time
+
+	// Standardize memory usage and limit to test aggregation
+	containerStats.Memory.Usage = uint64(5000)
+	containerStats.Memory.WorkingSet = uint64(602)
+
+	// Standardize the device name
 	new_fs := cadvisor.FsStats{}
 	f.Fuzz(&new_fs)
 	new_fs.Device = "/dev/device1"
@@ -504,7 +608,13 @@ func containerElementFactory(cmes []*cache.ContainerMetricElement) *cache.Contai
 	var metrics []*cache.ContainerMetricElement
 	if cmes == nil {
 		// If the argument is nil, generate two CMEs
-		metrics = []*cache.ContainerMetricElement{cmeFactory(), cmeFactory()}
+		cme_1 := cmeFactory()
+		cme_2 := cmeFactory()
+		for cme_1.Stats.Timestamp == cme_2.Stats.Timestamp {
+			// Ensure random but different timestamps
+			cme_2 = cmeFactory()
+		}
+		metrics = []*cache.ContainerMetricElement{cme_1, cme_2}
 	} else {
 		metrics = cmes
 	}
@@ -532,7 +642,14 @@ func podElementFactory() *cache.PodElement {
 		Hostname:  "testhost",
 		Labels:    make(map[string]string),
 	}
-	metrics := []*cache.ContainerMetricElement{cmeFactory(), cmeFactory()}
+	cme_1 := cmeFactory()
+	cme_2 := cmeFactory()
+	for cme_1.Stats.Timestamp == cme_2.Stats.Timestamp {
+		// Ensure random but different timestamps
+		cme_2 = cmeFactory()
+	}
+	metrics := []*cache.ContainerMetricElement{cme_1, cme_2}
+
 	new_ce := &cache.ContainerElement{
 		Metadata: container_metadata,
 		Metrics:  metrics,
@@ -555,13 +672,19 @@ func podElementFactory() *cache.PodElement {
 // The cache contains two pods, one with two containers and one without any containers.
 // The cache also contains a free container and a "machine"-tagged container.
 func cacheFactory() cache.Cache {
-	source_cache := cache.NewCache(time.Hour)
+	source_cache := cache.NewCache(24 * time.Hour)
 
-	// Generate 4 ContainerMetricElements
+	// Generate Container CMEs - same timestamp for aggregation
 	cme_1 := cmeFactory()
 	cme_2 := cmeFactory()
+	cme_2.Stats.Timestamp = cme_1.Stats.Timestamp
+
+	// Genete Machine CMEs - same timestamp for aggregation
 	cme_3 := cmeFactory()
 	cme_4 := cmeFactory()
+	cme_4.Stats.Timestamp = cme_3.Stats.Timestamp
+
+	cme_5 := cmeFactory()
 
 	// Generate a pod with two containers, and a pod without any containers
 	container1 := source_api.Container{
@@ -601,52 +724,36 @@ func cacheFactory() cache.Cache {
 		},
 	}
 
-	// Generate a machine container
+	// Generate two machine containers
 	machine_container := source_api.Container{
 		Name:     "/",
 		Hostname: "hostname2",
 		Spec:     *cme_3.Spec,
 		Stats:    []*cadvisor.ContainerStats{cme_3.Stats},
 	}
+	machine_container2 := source_api.Container{
+		Name:     "/",
+		Hostname: "hostname3",
+		Spec:     *cme_4.Spec,
+		Stats:    []*cadvisor.ContainerStats{cme_4.Stats},
+	}
 	// Generate a free container
 	free_container := source_api.Container{
 		Name:     "free_container1",
 		Hostname: "hostname2",
-		Spec:     *cme_4.Spec,
-		Stats:    []*cadvisor.ContainerStats{cme_4.Stats},
+		Spec:     *cme_5.Spec,
+		Stats:    []*cadvisor.ContainerStats{cme_5.Stats},
 	}
 
-	other_containers := []source_api.Container{machine_container, free_container}
+	other_containers := []source_api.Container{
+		machine_container,
+		machine_container2,
+		free_container,
+	}
 
 	// Enter everything in the cache
 	source_cache.StorePods(pods)
 	source_cache.StoreContainers(other_containers)
 
 	return source_cache
-}
-
-// verifyCacheFactoryCluster performs assertions over a ClusterInfo structure,
-// based on the values and structure generated by cacheFactory.
-func verifyCacheFactoryCluster(clinfo *ClusterInfo, t *testing.T) {
-	assert := assert.New(t)
-	assert.NotNil(clinfo.Nodes["hostname2"])
-	node2 := clinfo.Nodes["hostname2"]
-	assert.NotEmpty(node2.Metrics)
-	assert.Len(node2.FreeContainers, 1)
-	assert.NotNil(node2.FreeContainers["free_container1"])
-
-	assert.NotNil(clinfo.Nodes["hostname3"])
-	node3 := clinfo.Nodes["hostname3"]
-	assert.Empty(node3.Metrics)
-
-	assert.NotNil(clinfo.Namespaces["test"])
-	namespace := clinfo.Namespaces["test"]
-
-	assert.NotNil(namespace.Pods)
-	pod1_ptr := namespace.Pods["pod1"]
-	assert.Equal(pod1_ptr, node2.Pods["pod1"])
-	assert.Len(pod1_ptr.Containers, 2)
-	pod2_ptr := namespace.Pods["pod2"]
-	assert.Equal(pod2_ptr, node3.Pods["pod2"])
-	assert.Len(pod2_ptr.Containers, 0)
 }

--- a/schema/types.go
+++ b/schema/types.go
@@ -28,10 +28,7 @@ type Cluster interface {
 
 	// The Get operations extract internal types from the Cluster.
 	// The returned time.Time values signify the latest metric timestamp in the cluster.
-	// TODO(alex): Returning pointers is NOT safe, will be addressed in a later PR
-	GetAllClusterData() (*ClusterInfo, time.Time, error)
-	GetAllNodeData(string) (*NodeInfo, time.Time, error)
-	GetAllPodData(string, string) (*PodInfo, time.Time, error)
+	// TODO(alex): Get Operations are being reconstructed for [Schema 7]
 }
 
 // realCluster is an implementation of the Cluster interface.
@@ -41,6 +38,7 @@ type realCluster struct {
 	timestamp     time.Time
 	lock          sync.RWMutex
 	tsConstructor func() store.TimeStore
+	resolution    time.Duration
 	ClusterInfo
 }
 

--- a/schema/util.go
+++ b/schema/util.go
@@ -59,3 +59,71 @@ func addContainerToMap(container_name string, dict map[string]*ContainerInfo) *C
 	}
 	return container_ptr
 }
+
+// addTimePoints adds the values of two TimePoints as uint64.
+// addTimePoints returns a new TimePoint with the added Value fields
+// and the Timestamp of the first TimePoint.
+func addTimePoints(tp1 store.TimePoint, tp2 store.TimePoint) store.TimePoint {
+	return store.TimePoint{
+		Timestamp: tp1.Timestamp,
+		Value:     tp1.Value.(uint64) + tp2.Value.(uint64),
+	}
+}
+
+// popTPSlice pops the first element of a TimePoint Slice, removing it from the slice.
+// popTPSlice receives a *[]TimePoint and returns its first element.
+func popTPSlice(tps_ptr *[]store.TimePoint) *store.TimePoint {
+	if tps_ptr == nil {
+		return nil
+	}
+	tps := *tps_ptr
+	if len(tps) == 0 {
+		return nil
+	}
+	res := tps[0]
+	if len(tps) == 1 {
+		(*tps_ptr) = tps[0:0]
+	}
+	(*tps_ptr) = tps[1:]
+	return &res
+}
+
+// addMatchingTimeseries performs addition over two timeseries with unique timestamps.
+// addMatchingTimeseries returns a []TimePoint of the resulting aggregated.
+// Assumes time-descending order of both []TimePoint parameters and the return slice.
+func addMatchingTimeseries(left []store.TimePoint, right []store.TimePoint) []store.TimePoint {
+	var cur_left *store.TimePoint
+	var cur_right *store.TimePoint
+	result := []store.TimePoint{}
+
+	// Merge timeseries into result until either one is empty
+	cur_left = popTPSlice(&left)
+	cur_right = popTPSlice(&right)
+	for cur_left != nil && cur_right != nil {
+		if cur_left.Timestamp.Equal(cur_right.Timestamp) {
+			result = append(result, addTimePoints(*cur_left, *cur_right))
+			cur_left = popTPSlice(&left)
+			cur_right = popTPSlice(&right)
+		} else if cur_left.Timestamp.After(cur_right.Timestamp) {
+			result = append(result, *cur_left)
+			cur_left = popTPSlice(&left)
+		} else {
+			result = append(result, *cur_right)
+			cur_right = popTPSlice(&right)
+		}
+	}
+	if cur_left == nil && cur_right != nil {
+		result = append(result, *cur_right)
+	} else if cur_left != nil && cur_right == nil {
+		result = append(result, *cur_left)
+	}
+
+	// Append leftover elements from non-empty timeseries
+	if len(left) > 0 {
+		result = append(result, left...)
+	} else if len(right) > 0 {
+		result = append(result, right...)
+	}
+
+	return result
+}

--- a/schema/util_test.go
+++ b/schema/util_test.go
@@ -23,6 +23,14 @@ import (
 	"github.com/GoogleCloudPlatform/heapster/store"
 )
 
+// newTimePoint is a helper function that constructs TimePoints for other unit tests.
+func newTimePoint(stamp time.Time, val interface{}) store.TimePoint {
+	return store.TimePoint{
+		Timestamp: stamp,
+		Value:     val,
+	}
+}
+
 // TestLatestsTimestamp tests all flows of latestTimeStamp.
 func TestLatestTimestamp(t *testing.T) {
 	assert := assert.New(t)
@@ -39,7 +47,7 @@ func TestNewInfoType(t *testing.T) {
 		metrics = make(map[string]*store.TimeStore)
 		labels  = make(map[string]string)
 	)
-	new_store := store.NewGCStore(store.NewTimeStore(), time.Hour)
+	new_store := newTimeStore()
 	metrics["test"] = &new_store
 	labels["name"] = "test"
 	assert := assert.New(t)
@@ -72,4 +80,164 @@ func TestAddContainerToMap(t *testing.T) {
 	new_cinfo := addContainerToMap("new_container", new_map)
 	assert.Equal(new_map["new_container"], new_cinfo)
 	assert.Equal(cinfo, new_cinfo)
+}
+
+// TestAddTimePoints tests all flows of addTimePoints.
+func TestAddTimePoints(t *testing.T) {
+	var (
+		tp1 = store.TimePoint{
+			Timestamp: time.Unix(1434212800, 0),
+			Value:     uint64(500),
+		}
+		tp2 = store.TimePoint{
+			Timestamp: time.Unix(1434212805, 0),
+			Value:     uint64(700),
+		}
+		assert = assert.New(t)
+	)
+	new_tp := addTimePoints(tp1, tp2)
+	assert.Equal(new_tp.Timestamp, tp1.Timestamp)
+	assert.Equal(new_tp.Value.(uint64), tp1.Value.(uint64)+tp2.Value.(uint64))
+}
+
+// TestPopTPSlice tests all flows of PopTPSlice.
+func TestPopTPSlice(t *testing.T) {
+	var (
+		tp1 = store.TimePoint{
+			Timestamp: time.Now(),
+			Value:     uint64(3),
+		}
+		tp2 = store.TimePoint{
+			Timestamp: time.Now(),
+			Value:     uint64(4),
+		}
+		assert = assert.New(t)
+	)
+
+	// Invocations with no popped element
+	assert.Nil(popTPSlice(nil))
+	assert.Nil(popTPSlice(&[]store.TimePoint{}))
+
+	// Invocation with one element
+	tps := []store.TimePoint{tp1}
+	res := popTPSlice(&tps)
+	assert.Equal(*res, tp1)
+	assert.Empty(tps)
+
+	// Invocation with two elements
+	tps = []store.TimePoint{tp1, tp2}
+	res = popTPSlice(&tps)
+	assert.Equal(*res, tp1)
+	assert.Len(tps, 1)
+	assert.Equal(tps[0], tp2)
+}
+
+// TestAddMatchingTimeseries tests the normal flow of addMatchingTimeseries.
+func TestAddMatchingTimeseries(t *testing.T) {
+	var (
+		tp11 = store.TimePoint{
+			Timestamp: time.Unix(1434212800, 0),
+			Value:     uint64(4),
+		}
+		tp21 = store.TimePoint{
+			Timestamp: time.Unix(1434212805, 0),
+			Value:     uint64(9),
+		}
+		tp31 = store.TimePoint{
+			Timestamp: time.Unix(1434212807, 0),
+			Value:     uint64(10),
+		}
+		tp41 = store.TimePoint{
+			Timestamp: time.Unix(1434212850, 0),
+			Value:     uint64(533),
+		}
+
+		tp12 = store.TimePoint{
+			Timestamp: time.Unix(1434212800, 0),
+			Value:     uint64(4),
+		}
+		tp22 = store.TimePoint{
+			Timestamp: time.Unix(1434212806, 0),
+			Value:     uint64(8),
+		}
+		tp32 = store.TimePoint{
+			Timestamp: time.Unix(1434212807, 0),
+			Value:     uint64(11),
+		}
+		tp42 = store.TimePoint{
+			Timestamp: time.Unix(1434212851, 0),
+			Value:     uint64(534),
+		}
+		tp52 = store.TimePoint{
+			Timestamp: time.Unix(1434212859, 0),
+			Value:     uint64(538),
+		}
+		assert = assert.New(t)
+	)
+	// Invocation with 1+1 data points
+	tps1 := []store.TimePoint{tp11}
+	tps2 := []store.TimePoint{tp12}
+	new_ts := addMatchingTimeseries(tps1, tps2)
+	assert.Len(new_ts, 1)
+	assert.Equal(new_ts[0].Timestamp, tp11.Timestamp)
+	assert.Equal(new_ts[0].Value, uint64(8))
+
+	// Invocation with 3+1 data points
+	tps1 = []store.TimePoint{tp52, tp42, tp11}
+	tps2 = []store.TimePoint{tp12}
+	new_ts = addMatchingTimeseries(tps1, tps2)
+	assert.Len(new_ts, 3)
+	assert.Equal(new_ts[0], tp52)
+	assert.Equal(new_ts[1], tp42)
+	assert.Equal(new_ts[2].Timestamp, tp11.Timestamp)
+	assert.Equal(new_ts[2].Value, tp11.Value.(uint64)+tp12.Value.(uint64))
+
+	// Invocation with 4+5 data points
+	tps1 = []store.TimePoint{tp41, tp31, tp21, tp11}
+	tps2 = []store.TimePoint{tp52, tp42, tp32, tp22, tp12}
+	new_ts = addMatchingTimeseries(tps1, tps2)
+	assert.Len(new_ts, 7)
+	assert.Equal(new_ts[0], tp52)
+	assert.Equal(new_ts[1], tp42)
+	assert.Equal(new_ts[2], tp41)
+	assert.Equal(new_ts[3].Timestamp, tp31.Timestamp)
+	assert.Equal(new_ts[3].Value, uint64(21))
+	assert.Equal(new_ts[4], tp22)
+	assert.Equal(new_ts[5], tp21)
+	assert.Equal(new_ts[6].Timestamp, tp11.Timestamp)
+	assert.Equal(new_ts[6].Value, uint64(8))
+}
+
+// TestAddMatchingTimeseriesEmpty tests the alternate flows of addMatchingTimeseries.
+// Three permutations of empty parameters are tested.
+func TestAddMatchingTimeseriesEmpty(t *testing.T) {
+	var (
+		tp12 = store.TimePoint{
+			Timestamp: time.Unix(1434212800, 0),
+			Value:     uint64(4),
+		}
+		tp22 = store.TimePoint{
+			Timestamp: time.Unix(1434212806, 0),
+			Value:     uint64(8),
+		}
+		tp32 = store.TimePoint{
+			Timestamp: time.Unix(1434212807, 0),
+			Value:     uint64(11),
+		}
+		assert = assert.New(t)
+	)
+	empty_tps := []store.TimePoint{}
+	tps := []store.TimePoint{tp12, tp22, tp32}
+
+	// First call: first argument is empty
+	new_ts := addMatchingTimeseries(empty_tps, tps)
+	assert.Equal(new_ts, tps)
+
+	// Second call: second argument is empty
+	new_ts = addMatchingTimeseries(tps, empty_tps)
+	assert.Equal(new_ts, tps)
+
+	// Third call: both arguments are empty
+	new_ts = addMatchingTimeseries(empty_tps, empty_tps)
+	assert.Equal(new_ts, empty_tps)
 }

--- a/store/cma_store.go
+++ b/store/cma_store.go
@@ -93,7 +93,6 @@ func (ts *cmaStore) Get(start, end time.Time) []TimePoint {
 	for elem := ts.buffer.Front(); elem != nil; elem = elem.Next() {
 		tpc := elem.Value.(tpContainer)
 		entry := tpc.TimePoint
-
 		// Skip entries until the first one after start
 		if (start != zeroTime) && entry.Timestamp.Before(start) {
 			continue


### PR DESCRIPTION
Part 6 of #342 
This is #380, reopened due to ghost commits in the old PR.

This PR includes a full implementation of metric aggregation (summation) throughout the cluster structure.

New realCluster methods:
- aggregationStep: performs full aggregation of all entities in the structure, holds the cluster lock.
- aggregateNodeMetrics: sums Node metrics to generate Cluster metrics
- aggregateNamespaceMetrics: sums Pod metrics to generate Namespace metrics
- aggregatePodMetrics: sums Container metrics to generate Pod metrics
- aggregateMetrics: populates an InfoType by summing values from an []*InfoType

New utility functions:
- addTimePoints: adds the values of two TimePoints, returns a new TimePoint with the added value.
- popTPSlice: pops the first element of a []TimePoint.
- addMatchingTimeseries: adds two []TimePoint with matching timestamps, returns a new []TImePoint.

Misc updates:
- Removed the existing Get method from the implementation to avoid confusion. Getters are being redesigned at [Schema 7]

All methods that are not at 100% coverage contain internal error handling branches.

cc @rjnagal  @vmarmol @vishh