### PR TITLE
Fixed time range for collecting stats for every pass

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -80,7 +80,7 @@ func (rm *realManager) Housekeep() {
 	var sd syncData
 	start := rm.lastSync
 	end := time.Now()
-	rm.lastSync = start
+	rm.lastSync = end
 	glog.V(2).Infof("starting to scrape data from sources")
 	for idx := range rm.sources {
 		s := rm.sources[idx]


### PR DESCRIPTION
This should be merged and then pushed to Kubernetes ASAP because it may cause:
* exporting duplicated data
* increasing cpu/mem usage by Heapster due to increasing amount of data to process