### PR TITLE
Add support for modifying sinks at runtime

### DIFF
--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -6,7 +6,7 @@ via the `--sink` flag. The flag takes an argument of the form `PREFIX:CONFIG[?OP
 Options (optional!) are specified as URL query parameters, separated by `&` as normal.
 This allows each source to have custom configuration passed to it without needing to
 continually add new flags to Heapster as new sinks are added. This also means
-heapster can store data intomultiple sinks at once.
+heapster can store data into multiple sinks at once.
 
 ## Current sinks
 ### InfluxDB
@@ -75,3 +75,9 @@ If `HAWKULAR_SERVER_URL` includes any path, the default `hawkular/metrics` is ov
 The following options are available:
 
 * `tenant` - Hawkular-Metrics tenantId (default: `heapster`)
+
+## Modifying the sinks at runtime
+
+Using the `/api/v1/sinks` endpoint, it is possible to fetch the sinks
+currently in use via a GET request or to change them via a POST request. The
+format is the same as when passed via command line flags.

--- a/heapster.go
+++ b/heapster.go
@@ -86,16 +86,15 @@ func doWork() ([]api.Source, sinks.ExternalSinkManager, manager.Manager, error) 
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	externalSinks, err := newSinks()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	sinkManager, err := sinks.NewExternalSinkManager(externalSinks)
+	sinkManager, err := sinks.NewExternalSinkManager(nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	manager, err := manager.NewManager(sources, sinkManager, *argStatsResolution, *argCacheDuration, *argAlignStats)
 	if err != nil {
+		return nil, nil, nil, err
+	}
+	if err := manager.SetSinkUris(argSinks); err != nil {
 		return nil, nil, nil, err
 	}
 	go util.Until(manager.Housekeep, *argPollDuration, util.NeverStop)

--- a/manager/sinks.go
+++ b/manager/sinks.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package manager
 
 import (
 	"fmt"
@@ -22,9 +22,9 @@ import (
 	sink_api "github.com/GoogleCloudPlatform/heapster/sinks/api/v1"
 )
 
-func newSinks() ([]sink_api.ExternalSink, error) {
+func newSinks(sinkUris []string) ([]sink_api.ExternalSink, error) {
 	var sinks []sink_api.ExternalSink
-	for _, sinkFlag := range argSinks {
+	for _, sinkFlag := range sinkUris {
 		uri, err := url.Parse(sinkFlag)
 		if err != nil {
 			return nil, err

--- a/sinks/api/v1/external_sink.go
+++ b/sinks/api/v1/external_sink.go
@@ -22,6 +22,8 @@ import (
 type ExternalSink interface {
 	// Registers a metric with the backend.
 	Register([]MetricDescriptor) error
+	// Unregisters a metric with the backend.
+	Unregister([]MetricDescriptor) error
 	// Stores input data into the backend.
 	// Support input types are as follows:
 	// 1. []Timeseries

--- a/sinks/bigquery.go
+++ b/sinks/bigquery.go
@@ -274,7 +274,7 @@ func (self *bigquerySink) DebugInfo() string {
 }
 
 // Create a new bigquery storage driver.
-func NewBigQuerySink() (ExternalSinkManager, error) {
+func NewBigQuerySink() (Sink, error) {
 	bqClient, err := bigquery_client.NewClient()
 	if err != nil {
 		return nil, err

--- a/sinks/external_test.go
+++ b/sinks/external_test.go
@@ -1,0 +1,156 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sinks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	sink_api "github.com/GoogleCloudPlatform/heapster/sinks/api/v1"
+	source_api "github.com/GoogleCloudPlatform/heapster/sources/api"
+	kube_api "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+type DummySink struct {
+	Registered       int
+	Unregistered     int
+	StoredTimeseries int
+	StoredEvents     int
+}
+
+func (d *DummySink) Register([]sink_api.MetricDescriptor) error {
+	d.Registered++
+	return nil
+}
+
+func (d *DummySink) Unregister([]sink_api.MetricDescriptor) error {
+	d.Unregistered++
+	return nil
+}
+
+func (d *DummySink) StoreTimeseries([]sink_api.Timeseries) error {
+	d.StoredTimeseries++
+	return nil
+}
+
+func (d *DummySink) StoreEvents([]kube_api.Event) error {
+	d.StoredEvents++
+	return nil
+}
+
+func (d *DummySink) DebugInfo() string {
+	return ""
+}
+
+func (d *DummySink) Name() string {
+	return ""
+}
+
+func TestSetSinksRegister(t *testing.T) {
+	as := assert.New(t)
+	s1 := &DummySink{}
+	as.Equal(0, s1.Registered)
+	m, err := NewExternalSinkManager([]sink_api.ExternalSink{s1})
+	as.Nil(err)
+	as.Equal(1, s1.Registered)
+	err = m.SetSinks([]sink_api.ExternalSink{s1})
+	as.Nil(err)
+	s2 := &DummySink{}
+	as.Equal(1, s1.Registered)
+	as.Equal(0, s2.Registered)
+	err = m.SetSinks([]sink_api.ExternalSink{s2})
+	as.Nil(err)
+	as.Equal(1, s1.Registered)
+	as.Equal(1, s2.Registered)
+	err = m.SetSinks([]sink_api.ExternalSink{})
+	as.Nil(err)
+	as.Equal(1, s1.Registered)
+	as.Equal(1, s2.Registered)
+}
+
+func TestSetSinksUnregister(t *testing.T) {
+	as := assert.New(t)
+	s1 := &DummySink{}
+	as.Equal(0, s1.Unregistered)
+	m, err := NewExternalSinkManager([]sink_api.ExternalSink{s1})
+	as.Nil(err)
+	as.Equal(0, s1.Unregistered)
+	err = m.SetSinks([]sink_api.ExternalSink{s1})
+	as.Nil(err)
+	s2 := &DummySink{}
+	as.Equal(0, s1.Unregistered)
+	as.Equal(0, s2.Unregistered)
+	err = m.SetSinks([]sink_api.ExternalSink{s2})
+	as.Nil(err)
+	as.Equal(1, s1.Unregistered)
+	as.Equal(0, s2.Unregistered)
+	err = m.SetSinks([]sink_api.ExternalSink{})
+	as.Nil(err)
+	as.Equal(1, s1.Unregistered)
+	as.Equal(1, s2.Unregistered)
+}
+
+func TestSetSinksRegisterAgain(t *testing.T) {
+	as := assert.New(t)
+	s1 := &DummySink{}
+	as.Equal(0, s1.Registered)
+	as.Equal(0, s1.Unregistered)
+	m, err := NewExternalSinkManager([]sink_api.ExternalSink{s1})
+	as.Nil(err)
+	as.Equal(1, s1.Registered)
+	as.Equal(0, s1.Unregistered)
+	err = m.SetSinks([]sink_api.ExternalSink{})
+	as.Nil(err)
+	as.Equal(1, s1.Registered)
+	as.Equal(1, s1.Unregistered)
+	err = m.SetSinks([]sink_api.ExternalSink{s1})
+	as.Nil(err)
+	as.Equal(2, s1.Registered)
+	as.Equal(1, s1.Unregistered)
+	err = m.SetSinks([]sink_api.ExternalSink{})
+	as.Nil(err)
+	as.Equal(2, s1.Registered)
+	as.Equal(2, s1.Unregistered)
+}
+
+func TestSetSinksStore(t *testing.T) {
+	as := assert.New(t)
+	s1 := &DummySink{}
+	m, err := NewExternalSinkManager([]sink_api.ExternalSink{s1})
+	as.Nil(err)
+	as.Equal(0, s1.StoredTimeseries)
+	as.Equal(0, s1.StoredEvents)
+	err = m.Store(source_api.AggregateData{})
+	as.Nil(err)
+	as.Equal(1, s1.StoredTimeseries)
+	as.Equal(1, s1.StoredEvents)
+	err = m.SetSinks([]sink_api.ExternalSink{})
+	as.Nil(err)
+	err = m.Store(source_api.AggregateData{})
+	as.Nil(err)
+	as.Equal(1, s1.StoredTimeseries)
+	as.Equal(1, s1.StoredEvents)
+	err = m.SetSinks([]sink_api.ExternalSink{s1})
+	as.Nil(err)
+	err = m.Store(source_api.AggregateData{})
+	as.Nil(err)
+	as.Equal(2, s1.StoredTimeseries)
+	as.Equal(2, s1.StoredEvents)
+	err = m.Store(source_api.AggregateData{})
+	as.Nil(err)
+	as.Equal(3, s1.StoredTimeseries)
+	as.Equal(3, s1.StoredEvents)
+}

--- a/sinks/gcl/driver.go
+++ b/sinks/gcl/driver.go
@@ -51,6 +51,11 @@ func (sink *gclSink) Register(metrics []sink_api.MetricDescriptor) error {
 	return nil
 }
 
+func (sink *gclSink) Unregister(metrics []sink_api.MetricDescriptor) error {
+	// No-op
+	return nil
+}
+
 // Stores metrics into the backend
 func (sink *gclSink) StoreTimeseries(input []sink_api.Timeseries) error {
 	// No-op, Google Cloud Logging (GCL) doesn't store metrics

--- a/sinks/gcm/core.go
+++ b/sinks/gcm/core.go
@@ -190,6 +190,11 @@ func (self *GcmCore) Register(name, description, metricType, valueType string, l
 	return nil
 }
 
+func (self *GcmCore) Unregister(name string) error {
+	// No-op
+	return nil
+}
+
 // GCM request structures for writing time-series data.
 type timeseriesDescriptor struct {
 	Project string            `json:"project,omitempty"`

--- a/sinks/gcm/driver.go
+++ b/sinks/gcm/driver.go
@@ -41,6 +41,20 @@ func (self gcmSink) Register(metrics []sink_api.MetricDescriptor) error {
 	return nil
 }
 
+func (self gcmSink) Unregister(metrics []sink_api.MetricDescriptor) error {
+	for _, metric := range metrics {
+		if err := self.core.Unregister(metric.Name); err != nil {
+			return err
+		}
+		if rateMetric, exists := gcmRateMetrics[metric.Name]; exists {
+			if err := self.core.Unregister(rateMetric.name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // Stores events into the backend.
 func (self gcmSink) StoreEvents([]kube_api.Event) error {
 	// No-op, Google Cloud Monitoring doesn't store events

--- a/sinks/gcmautoscaling/driver.go
+++ b/sinks/gcmautoscaling/driver.go
@@ -98,6 +98,15 @@ func (self gcmAutocalingSink) Register(_ []sink_api.MetricDescriptor) error {
 	return nil
 }
 
+func (self gcmAutocalingSink) Unregister(_ []sink_api.MetricDescriptor) error {
+	for _, metric := range autoscalingMetrics {
+		if err := self.core.Unregister(metric.name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Stores events into the backend.
 func (self gcmAutocalingSink) StoreEvents([]kube_api.Event) error {
 	// No-op, Google Cloud Monitoring doesn't store events

--- a/sinks/hawkular/driver.go
+++ b/sinks/hawkular/driver.go
@@ -43,6 +43,9 @@ type hawkularSink struct {
 	models  map[string]metrics.MetricDefinition // Model definitions
 	regLock sync.Mutex
 	reg     map[string]*metrics.MetricDefinition // Real definitions
+
+	uri  string
+	opts map[string][]string
 }
 
 // START: ExternalSink interface implementations
@@ -77,6 +80,12 @@ func (self *hawkularSink) Register(mds []sink_api.MetricDescriptor) error {
 	}
 
 	return nil
+}
+
+func (self *hawkularSink) Unregister(mds []sink_api.MetricDescriptor) error {
+	self.regLock.Lock()
+	defer self.regLock.Unlock()
+	return self.init()
 }
 
 // Checks that stored definition is up to date with the model
@@ -248,11 +257,10 @@ func init() {
 	extpoints.SinkFactories.Register(NewHawkularSink, "hawkular")
 }
 
-func NewHawkularSink(uri string, options map[string][]string) ([]sink_api.ExternalSink, error) {
-
-	parsedUrl, err := url.Parse(os.ExpandEnv(uri))
+func (self *hawkularSink) init() error {
+	parsedUrl, err := url.Parse(os.ExpandEnv(self.uri))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	p := metrics.Parameters{
@@ -265,20 +273,30 @@ func NewHawkularSink(uri string, options map[string][]string) ([]sink_api.Extern
 		p.Path = parsedUrl.Path
 	}
 
-	if v, found := options["tenant"]; found {
+	if v, found := self.opts["tenant"]; found {
 		p.Tenant = v[0]
 	}
 
 	c, err := metrics.NewHawkularClient(p)
 	if err != nil {
+		return err
+	}
+
+	self.client = c
+	self.reg = make(map[string]*metrics.MetricDefinition)
+	self.models = make(map[string]metrics.MetricDefinition)
+
+	glog.Infof("Initialised Hawkular Sink with parameters %v", p)
+	return nil
+}
+
+func NewHawkularSink(uri string, options map[string][]string) ([]sink_api.ExternalSink, error) {
+	sink := &hawkularSink{
+		uri:  uri,
+		opts: options,
+	}
+	if err := sink.init(); err != nil {
 		return nil, err
 	}
-	glog.Infof("Created Hawkular Sink with parameters %v", p)
-
-	hSink := &hawkularSink{client: c,
-		reg:    make(map[string]*metrics.MetricDefinition),
-		models: make(map[string]metrics.MetricDefinition),
-	}
-
-	return []sink_api.ExternalSink{hSink}, nil
+	return []sink_api.ExternalSink{sink}, nil
 }

--- a/sinks/influxdb/driver.go
+++ b/sinks/influxdb/driver.go
@@ -70,6 +70,11 @@ func (self *influxdbSink) Register(metrics []sink_api.MetricDescriptor) error {
 	return nil
 }
 
+func (self *influxdbSink) Unregister(metrics []sink_api.MetricDescriptor) error {
+	// Like Register
+	return nil
+}
+
 func (self *influxdbSink) metricToSeries(timeseries *sink_api.Timeseries) *influxdb.Series {
 	columns := []string{}
 	values := []interface{}{}

--- a/sinks/memory.go
+++ b/sinks/memory.go
@@ -63,7 +63,7 @@ func (self *MemorySink) DebugInfo() string {
 	return desc
 }
 
-func NewMemorySink() ExternalSinkManager {
+func NewMemorySink() Sink {
 	return &MemorySink{
 		containersData:     list.New(),
 		oldestData:         time.Now(),

--- a/sinks/types.go
+++ b/sinks/types.go
@@ -15,8 +15,17 @@
 // This package implements the various storage backends supported by heapster.
 package sinks
 
+import "github.com/GoogleCloudPlatform/heapster/sinks/api/v1"
+
 // TODO: Once in-memory storage is implemented, make the manager extract data from the in-memory store periodically.
-type ExternalSinkManager interface {
+type Sink interface {
 	Store(input interface{}) error
 	DebugInfo() string
+}
+
+type ExternalSinkManager interface {
+	Sink
+	// SetSinks changes the sinks to be used and registers/unregisters
+	// them accordingly.
+	SetSinks([]v1.ExternalSink) error
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -27,7 +27,7 @@ const (
 	ValidatePage = "/validate/"
 )
 
-func HandleRequest(w http.ResponseWriter, sources []api.Source, sink sinks.ExternalSinkManager) error {
+func HandleRequest(w http.ResponseWriter, sources []api.Source, sink sinks.Sink) error {
 	out := fmt.Sprintf("Heapster Version: %v\n\n", version.HeapsterVersion)
 	for _, source := range sources {
 		out += source.DebugInfo()


### PR DESCRIPTION
Added a new API endpoint, /api/v1/sinks, that returns the sink uris on GET and
lets you set them via a POST. The sink uris work just like when you pass them
as flags.

Had to split the ExternalSinkManager interface into Sink for actual sinks and
ExternalSinkManager for the actual managers (only sinks/external.go for now).
The latter adds a new method, SetSinks(), which is what we use here.

Since sinks may now be removed at runtime, an Unregister() function in the
ExternalSink interface was added. The implementations have been left as TODOs
for now - what each one will do depends on the implementation, just like
Regsiter().

CC @vmarmol @vishh