### PR TITLE
Properly do all kubeVersions in the integration tests

### DIFF
--- a/integration/heapster_api_test.go
+++ b/integration/heapster_api_test.go
@@ -372,7 +372,9 @@ func runApiTest() error {
 	}
 	kubeVersionsList := strings.Split(*kubeVersions, ",")
 	for _, kubeVersion := range kubeVersionsList {
-		return apiTest(kubeVersion)
+		if err := apiTest(kubeVersion); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
If we always return at each iteration, we'll only ever test the first version.
Seems like a typo or silly mistake.