### PR TITLE
[Schema->Model] Rename the Schema package to Model

### DIFF
--- a/model/aggregation.go
+++ b/model/aggregation.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schema
+package model
 
 import (
 	"fmt"

--- a/model/aggregation_test.go
+++ b/model/aggregation_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schema
+package model
 
 import (
 	"testing"

--- a/model/impl.go
+++ b/model/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schema
+package model
 
 import (
 	"fmt"
@@ -272,7 +272,7 @@ func (rc *realCluster) parseMetric(cme *cache.ContainerMetricElement, dict map[s
 func (rc *realCluster) Update(c cache.Cache) error {
 	var zero time.Time
 	latest_time := rc.timestamp
-	glog.V(2).Infoln("Schema Update operation started")
+	glog.V(2).Infoln("Model Update operation started")
 
 	// Invoke cache methods using the Cluster timestamp
 	nodes := c.GetNodes(rc.timestamp, zero)
@@ -308,7 +308,7 @@ func (rc *realCluster) Update(c cache.Cache) error {
 	// Update the Cluster timestamp to the latest time found in the new metrics
 	rc.updateTime(latest_time)
 
-	glog.V(2).Infoln("Schema Update operation completed")
+	glog.V(2).Infoln("Model Update operation completed")
 	return nil
 }
 

--- a/model/impl_test.go
+++ b/model/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schema
+package model
 
 import (
 	"math/rand"

--- a/model/types.go
+++ b/model/types.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schema
+package model
 
 import (
 	"sync"

--- a/model/util.go
+++ b/model/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schema
+package model
 
 import (
 	"time"

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schema
+package model
 
 import (
 	"testing"


### PR DESCRIPTION
This PR renames the schema package to model, as it is a more fitting name and avoids confusion with actual schema references in the codebase.

From now on, all further PRs will be prefixed with [Model X]. Specifically, the next PR will be [Model 7], which will implement some basic cluster-level API endpoints.

\cc @rjnagal @vmarmol 