### PR TITLE
Fix onlyKeepLatestStat to return the latest rather than the oldest stat

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -177,7 +177,7 @@ func trimStatsForContainers(containers []*cache.ContainerElement) []*cache.Conta
 // Only keep the latest stats data point.
 func onlyKeepLatestStat(cont *cache.ContainerElement) {
 	if len(cont.Metrics) > 1 {
-		cont.Metrics = cont.Metrics[len(cont.Metrics)-1:]
+		cont.Metrics = cont.Metrics[0:1]
 	}
 }
 

--- a/sinks/cache/cache.go
+++ b/sinks/cache/cache.go
@@ -38,6 +38,7 @@ type ContainerMetricElement struct {
 
 type ContainerElement struct {
 	Metadata
+	// Data points are in reverse chronological order (most recent to oldest).
 	Metrics []*ContainerMetricElement
 }
 


### PR DESCRIPTION
This was causing the REST API to return nearly 10 minute old data due to the default 10 minute buffer in the GC store.

As a pretty strong disclaimer, I haven't actually tested this in a cluster and I didn't see any unit tests that it'd be easy to add a check for this to. The unit tests do all pass, however. I can spend some time trying to test it in a live cluster tomorrow if you'd like.

@vmarmol 