### PR TITLE
Exit on any shell script errors equally on all scripts

### DIFF
--- a/influxdb/run.sh
+++ b/influxdb/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -m
+set -e -m
 
 CONFIG_FILE="/config/config.toml"
 API_URL="http://localhost:8086"

--- a/integration/.jenkins.sh
+++ b/integration/.jenkins.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -x
+
+set -e -x
 
 export GOPATH="$JENKINS_HOME/workspace/project"
 export GOBIN="$GOPATH/bin"


### PR DESCRIPTION
Especially on the jenkins one, since we don't want to run the integration
tests if the unit tests already failed.

CC @vishh 

You can see an example of this problem here:

http://104.154.52.74/job/heapster-e2e-gce/1714/console

`make` fails, but `godep` is run anyway.