### PR TITLE
[Model 8] REST API polishing, cleanup and extensions

### DIFF
--- a/api/v1/model_handlers.go
+++ b/api/v1/model_handlers.go
@@ -21,12 +21,13 @@ import (
 	restful "github.com/emicklei/go-restful"
 	"github.com/golang/glog"
 
+	"github.com/GoogleCloudPlatform/heapster/model"
 	"github.com/GoogleCloudPlatform/heapster/store"
 )
 
 // RegisterModel registers the Model API endpoints.
 // All endpoints that end with a {metric-name} also receive a start time query parameter.
-// The start time should be specified as a string, formatted according to RFC 3339.
+// The start and end times should be specified as a string, formatted according to RFC 3339.
 func (a *Api) RegisterModel(container *restful.Container) {
 	ws := new(restful.WebService)
 	ws.
@@ -35,26 +36,58 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		Consumes("*/*").
 		Produces(restful.MIME_JSON)
 
-	// The / endpoint returns a list of all the metrics that are available in the model
+	// The / endpoint returns a list of all the entities that are available in the cluster
 	ws.Route(ws.GET("/").
+		To(a.allEntities).
+		Filter(compressionFilter).
+		Doc("Get a list of all entities available in the model").
+		Operation("allEntities"))
+
+	// The /metrics/ endpoint returns a list of all available metrics for the Cluster entity of the model.
+	ws.Route(ws.GET("/metrics/").
 		To(a.availableMetrics).
 		Filter(compressionFilter).
-		Doc("Show which metrics are available").
-		Operation("clusterMetrics"))
+		Doc("Get a list of all available metrics for the Cluster entity").
+		Operation("availableMetrics"))
 
-	// The /cluster/{metric-name} endpoint exposes an aggregated metric for the Cluster entity of the model.
-	ws.Route(ws.GET("/cluster/{metric-name}").
+	// The /metrics/{metric-name} endpoint exposes an aggregated metric for the Cluster entity of the model.
+	ws.Route(ws.GET("/metrics/{metric-name}").
 		To(a.clusterMetrics).
 		Filter(compressionFilter).
 		Doc("Export an aggregated cluster-level metric").
 		Operation("clusterMetrics").
 		Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
 		Param(ws.QueryParameter("start", "Start time for requested metric").DataType("string")).
+		Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
 		Writes(MetricResult{}))
 
-	// The /nodes/{node-name}/{metric-name} endpoint exposes a metric for a Node entity of the model.
+	// The /nodes/ endpoint returns a list of all Node entities in the cluster.
+	ws.Route(ws.GET("/nodes/").
+		To(a.allNodes).
+		Filter(compressionFilter).
+		Doc("Get a list of all Nodes in the model").
+		Operation("allNodes").
+		Writes(MetricResult{}))
+
+	// The /nodes/{node-name} endpoint returns a list of all available API paths for a Node entity.
+	ws.Route(ws.GET("/nodes/{node-name}").
+		To(a.nodePaths).
+		Filter(compressionFilter).
+		Doc("Get a list of all available API paths for a Node entity").
+		Operation("nodePaths").
+		Param(ws.PathParameter("node-name", "The name of the node to lookup").DataType("string")))
+
+	// The /nodes/{node-name}/metrics endpoint returns a list of all available metrics for a Node entity.
+	ws.Route(ws.GET("/nodes/{node-name}/metrics/").
+		To(a.availableMetrics).
+		Filter(compressionFilter).
+		Doc("Get a list of all available metrics for a Node entity").
+		Operation("availableMetrics").
+		Param(ws.PathParameter("node-name", "The name of the node to lookup").DataType("string")))
+
+	// The /nodes/{node-name}/metrics/{metric-name} endpoint exposes a metric for a Node entity of the model.
 	// The {node-name} parameter is the hostname of a specific node.
-	ws.Route(ws.GET("/nodes/{node-name}/{metric-name}").
+	ws.Route(ws.GET("/nodes/{node-name}/metrics/{metric-name}").
 		To(a.nodeMetrics).
 		Filter(compressionFilter).
 		Doc("Export a node-level metric").
@@ -62,48 +95,167 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		Param(ws.PathParameter("node-name", "The name of the node to lookup").DataType("string")).
 		Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
 		Param(ws.QueryParameter("start", "Start time for requested metric").DataType("string")).
+		Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
 		Writes(MetricResult{}))
 
-	// The /namespaces/{namespace-name}/{metric-name} endpoint exposes an aggregated metrics
+	// The /namespaces/ endpoint returns a list of all Namespace entities in the cluster.
+	ws.Route(ws.GET("/namespaces/").
+		To(a.allNamespaces).
+		Filter(compressionFilter).
+		Doc("Get a list of all Namespaces in the model").
+		Operation("allNamespaces"))
+
+	// The /namespaces/{namespace-name} endpoint returns a list of all available API Paths for a Namespace entity.
+	ws.Route(ws.GET("/namespaces/{namespace-name}").
+		To(a.namespacePaths).
+		Filter(compressionFilter).
+		Doc("Get a list of all available API paths for a namespace entity").
+		Operation("namespacePaths").
+		Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")))
+
+	// The /namespaces/{namespace-name}/metrics endpoint returns a list of all available metrics for a Namespace entity.
+	ws.Route(ws.GET("/namespaces/{namespace-name}/metrics").
+		To(a.availableMetrics).
+		Filter(compressionFilter).
+		Doc("Get a list of all available metrics for a Namespace entity").
+		Operation("availableMetrics").
+		Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")))
+
+	// The /namespaces/{namespace-name}/metrics/{metric-name} endpoint exposes an aggregated metrics
 	// for a Namespace entity of the model.
-	ws.Route(ws.GET("/namespaces/{namespace-name}/{metric-name}").
+	ws.Route(ws.GET("/namespaces/{namespace-name}/metrics/{metric-name}").
 		To(a.namespaceMetrics).
 		Filter(compressionFilter).
 		Doc("Export an aggregated namespace-level metric").
 		Operation("namespaceMetrics").
+		Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
 		Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
 		Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+		Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
 		Writes(MetricResult{}))
 
-	// The /namespaces/{namespace-name}/pods/{pod-name}/{metric-name} endpoint exposes
+	// The /namespaces/{namespace-name}/pods endpoint returns a list of all Pod entities in the cluster,
+	// under a specified namespace.
+	ws.Route(ws.GET("/namespaces/{namespace-name}/pods").
+		To(a.allPods).
+		Filter(compressionFilter).
+		Doc("Get a list of all Pods in the model, belonging to the specified Namespace").
+		Operation("allPods").
+		Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")))
+
+	// The /namespaces/{namespace-name}/pods/{pod-name} endpoint returns a list of all
+	// API paths available for a pod
+	ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}").
+		To(a.podPaths).
+		Filter(compressionFilter).
+		Doc("Get a list of all API paths available for a Pod entity").
+		Operation("podPaths").
+		Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
+		Param(ws.PathParameter("pod-name", "The name of the pod to lookup").DataType("string")))
+
+	// The /namespaces/{namespace-name}/pods/{pod-name}/metrics endpoint returns a list of all available metrics for a Pod entity.
+	ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/metrics").
+		To(a.availableMetrics).
+		Filter(compressionFilter).
+		Doc("Get a list of all available metrics for a Pod entity").
+		Operation("availableMetrics").
+		Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
+		Param(ws.PathParameter("pod-name", "The name of the pod to lookup").DataType("string")))
+
+	// The /namespaces/{namespace-name}/pods/{pod-name}/metrics/{metric-name} endpoint exposes
 	// an aggregated metric for a Pod entity of the model.
-	ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/{metric-name}").
+	ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/metrics/{metric-name}").
 		To(a.podMetrics).
 		Filter(compressionFilter).
 		Doc("Export an aggregated pod-level metric").
 		Operation("podMetrics").
-		Param(ws.PathParameter("namespace-name", "The name of the namespace to use").DataType("string")).
-		Param(ws.PathParameter("pod-name", "The name of the pod to use").DataType("string")).
+		Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
+		Param(ws.PathParameter("pod-name", "The name of the pod to lookup").DataType("string")).
 		Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
 		Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+		Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
 		Writes(MetricResult{}))
+	// The /namespaces/{namespace-name}/pods/{pod-name}/containers endpoint returns a list of all Container entities,
+	// under a specified namespace and pod.
+	ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/containers").
+		To(a.allPodContainers).
+		Filter(compressionFilter).
+		Doc("Get a list of all Containers in the model, belonging to the specified Namespace and Pod").
+		Operation("allPodContainers").
+		Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
+		Param(ws.PathParameter("pod-name", "The name of the pod to lookup").DataType("string")))
 
-	// The /namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/{metric-name} endpoint exposes
+	// The /namespaces/{namespace-name}/pods/{pod-name}/containers/metrics/{container-name} endpoint
+	// returns a list of all API paths available for a Pod Container
+	ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}").
+		To(a.containerPaths).
+		Filter(compressionFilter).
+		Doc("Get a list of all API paths available for a Pod Container entity").
+		Operation("containerPaths").
+		Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
+		Param(ws.PathParameter("pod-name", "The name of the pod to lookup").DataType("string")).
+		Param(ws.PathParameter("container-name", "The name of the namespace to use").DataType("string")))
+
+	// The /namespaces/{namespace-name}/pods/{pod-name}/containers/metrics/{container-name}/metrics endpoint
+	// returns a list of all available metrics for a Pod Container entity.
+	ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/metrics").
+		To(a.availableMetrics).
+		Filter(compressionFilter).
+		Doc("Get a list of all available metrics for a Pod entity").
+		Operation("availableMetrics").
+		Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
+		Param(ws.PathParameter("pod-name", "The name of the pod to lookup").DataType("string")).
+		Param(ws.PathParameter("container-name", "The name of the namespace to use").DataType("string")))
+
+	// The /namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/metrics/{metric-name} endpoint exposes
 	// a metric for a Container entity of the model.
-	ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/{metric-name}").
+	ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/metrics/{metric-name}").
 		To(a.podContainerMetrics).
 		Filter(compressionFilter).
-		Doc("Export an aggregated metric for a pod container").
+		Doc("Export an aggregated metric for a Pod Container").
 		Operation("podContainerMetrics").
 		Param(ws.PathParameter("namespace-name", "The name of the namespace to use").DataType("string")).
 		Param(ws.PathParameter("pod-name", "The name of the pod to use").DataType("string")).
+		Param(ws.PathParameter("container-name", "The name of the namespace to use").DataType("string")).
 		Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
 		Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+		Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
 		Writes(MetricResult{}))
 
-	// The /nodes/{node-name}/freecontainers/{container-name}/{metric-name} endpoint exposes
+	// The /nodes/{node-name}/freecontainers/ endpoint returns a list of all free Container entities,
+	// under a specified node.
+	ws.Route(ws.GET("/nodes/{node-name}/freecontainers/").
+		To(a.allFreeContainers).
+		Filter(compressionFilter).
+		Doc("Get a list of all free Containers in the model, belonging to the specified Node").
+		Operation("allFreeContainers").
+		Param(ws.PathParameter("node-name", "The name of the namespace to lookup").DataType("string")))
+
+	// The /nodes/{node-name}/freecontainers/{container-name}/ endpoint exposes
+	// the available subpaths for a free container
+	ws.Route(ws.GET("/nodes/{node-name}/freecontainers/{container-name}/").
+		To(a.containerPaths).
+		Filter(compressionFilter).
+		Doc("Get a list of API paths for a free Container entity").
+		Operation("freeContainerMetrics").
+		Param(ws.PathParameter("node-name", "The name of the node to use").DataType("string")).
+		Param(ws.PathParameter("container-name", "The name of the container to use").DataType("string")).
+		Writes(MetricResult{}))
+
+	// The /nodes/{node-name}/freecontainers/{container-name}/metrics endpoint
+	// returns a list of all available metrics for a Free Container entity.
+	ws.Route(ws.GET("/nodes/{node-name}/freecontainers/{container-name}/metrics").
+		To(a.availableMetrics).
+		Filter(compressionFilter).
+		Doc("Get a list of all available metrics for a free Container entity").
+		Operation("availableMetrics").
+		Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
+		Param(ws.PathParameter("pod-name", "The name of the pod to lookup").DataType("string")).
+		Param(ws.PathParameter("container-name", "The name of the namespace to use").DataType("string")))
+
+	// The /nodes/{node-name}/freecontainers/{container-name}/metrics/{metric-name} endpoint exposes
 	// a metric for a free Container entity of the model.
-	ws.Route(ws.GET("/nodes/{node-name}/freecontainers/{container-name}/{metric-name}").
+	ws.Route(ws.GET("/nodes/{node-name}/freecontainers/{container-name}/metrics/{metric-name}").
 		To(a.freeContainerMetrics).
 		Filter(compressionFilter).
 		Doc("Export a container-level metric for a free container").
@@ -112,12 +264,92 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		Param(ws.PathParameter("container-name", "The name of the container to use").DataType("string")).
 		Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
 		Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+		Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
 		Writes(MetricResult{}))
 
 	container.Add(ws)
 }
 
-// availableMetrics returns a list of available metric names, to be reported to the /metrics endpoint.
+// allEntities returns a list of all the top-level paths that are available in the API.
+func (a *Api) allEntities(request *restful.Request, response *restful.Response) {
+	entities := []string{
+		"metrics/",
+		"namespaces/",
+		"nodes/",
+	}
+	response.WriteEntity(entities)
+}
+
+// namespacePaths returns a list of all the available API paths that are available for a namespace.
+func (a *Api) namespacePaths(request *restful.Request, response *restful.Response) {
+	entities := []string{
+		"pods/",
+		"metrics/",
+	}
+	response.WriteEntity(entities)
+}
+
+// nodePaths returns a list of all the available API paths that are available for a node.
+func (a *Api) nodePaths(request *restful.Request, response *restful.Response) {
+	entities := []string{
+		"freecontainers/",
+		"metrics/",
+	}
+	response.WriteEntity(entities)
+}
+
+// podPaths returns a list of all the available API paths that are available for a pod.
+func (a *Api) podPaths(request *restful.Request, response *restful.Response) {
+	entities := []string{
+		"containers/",
+		"metrics/",
+	}
+	response.WriteEntity(entities)
+}
+
+// containerPaths returns a list of all the available API paths that are available for a container.
+func (a *Api) containerPaths(request *restful.Request, response *restful.Response) {
+	entities := []string{
+		"metrics/",
+	}
+	response.WriteEntity(entities)
+}
+
+// allNodes returns a list of all the available node names in the cluster.
+func (a *Api) allNodes(request *restful.Request, response *restful.Response) {
+	cluster := a.manager.GetCluster()
+	response.WriteEntity(cluster.GetNodes())
+}
+
+// allNamespaces returns a list of all the available namespaces in the cluster.
+func (a *Api) allNamespaces(request *restful.Request, response *restful.Response) {
+	cluster := a.manager.GetCluster()
+	response.WriteEntity(cluster.GetNamespaces())
+}
+
+// allPods returns a list of all the available pods in the cluster.
+func (a *Api) allPods(request *restful.Request, response *restful.Response) {
+	cluster := a.manager.GetCluster()
+	namespace := request.PathParameter("namespace-name")
+	response.WriteEntity(cluster.GetPods(namespace))
+}
+
+// allPodContainers returns a list of all the available pod containers in the cluster.
+func (a *Api) allPodContainers(request *restful.Request, response *restful.Response) {
+	cluster := a.manager.GetCluster()
+	namespace := request.PathParameter("namespace-name")
+	pod := request.PathParameter("pod-name")
+	response.WriteEntity(cluster.GetPodContainers(namespace, pod))
+}
+
+// allFreeContainers returns a list of all the available free containers in the cluster.
+func (a *Api) allFreeContainers(request *restful.Request, response *restful.Response) {
+	cluster := a.manager.GetCluster()
+	node := request.PathParameter("node-name")
+	response.WriteEntity(cluster.GetFreeContainers(node))
+}
+
+// availableMetrics returns a list of available metric names.
 // These metric names can be used to extract metrics from the various model entities.
 func (a *Api) availableMetrics(request *restful.Request, response *restful.Response) {
 	cluster := a.manager.GetCluster()
@@ -128,13 +360,12 @@ func (a *Api) availableMetrics(request *restful.Request, response *restful.Respo
 // clusterMetrics returns a metric timeseries for a metric of the Cluster entity.
 func (a *Api) clusterMetrics(request *restful.Request, response *restful.Response) {
 	cluster := a.manager.GetCluster()
-	// Get metric name
-	metric_name := request.PathParameter("metric-name")
 
-	// Get start time, parse as time.Time
-	req_stamp := parseRequestStartParam(request, response)
-
-	timeseries, new_stamp, err := cluster.GetClusterMetric(metric_name, req_stamp)
+	timeseries, new_stamp, err := cluster.GetClusterMetric(model.ClusterRequest{
+		MetricName: request.PathParameter("metric-name"),
+		Start:      parseRequestParam("start", request, response),
+		End:        parseRequestParam("end", request, response),
+	})
 	if err != nil {
 		response.WriteError(http.StatusInternalServerError, err)
 		glog.Errorf("unable to get cluster metric: %s", err)
@@ -147,19 +378,15 @@ func (a *Api) clusterMetrics(request *restful.Request, response *restful.Respons
 func (a *Api) nodeMetrics(request *restful.Request, response *restful.Response) {
 	cluster := a.manager.GetCluster()
 
-	// Get node name (hostname)
-	hostname := request.PathParameter("node-name")
-
-	// Get metric name
-	metric_name := request.PathParameter("metric-name")
-
-	// Get start time, parse as time.Time
-	req_stamp := parseRequestStartParam(request, response)
-
-	timeseries, new_stamp, err := cluster.GetNodeMetric(hostname, metric_name, req_stamp)
+	timeseries, new_stamp, err := cluster.GetNodeMetric(model.NodeRequest{
+		NodeName:   request.PathParameter("node-name"),
+		MetricName: request.PathParameter("metric-name"),
+		Start:      parseRequestParam("start", request, response),
+		End:        parseRequestParam("end", request, response),
+	})
 	if err != nil {
 		response.WriteError(http.StatusInternalServerError, err)
-		glog.Errorf("unable to get cluster metric: %s", err)
+		glog.Errorf("unable to get node metric: %s", err)
 		return
 	}
 	response.WriteEntity(exportTimeseries(timeseries, new_stamp))
@@ -169,19 +396,15 @@ func (a *Api) nodeMetrics(request *restful.Request, response *restful.Response) 
 func (a *Api) namespaceMetrics(request *restful.Request, response *restful.Response) {
 	cluster := a.manager.GetCluster()
 
-	// Get namespace name
-	namespace := request.PathParameter("namespace-name")
-
-	// Get metric name
-	metric_name := request.PathParameter("metric-name")
-
-	// Get start time, parse as time.Time
-	req_stamp := parseRequestStartParam(request, response)
-
-	timeseries, new_stamp, err := cluster.GetNamespaceMetric(namespace, metric_name, req_stamp)
+	timeseries, new_stamp, err := cluster.GetNamespaceMetric(model.NamespaceRequest{
+		NamespaceName: request.PathParameter("namespace-name"),
+		MetricName:    request.PathParameter("metric-name"),
+		Start:         parseRequestParam("start", request, response),
+		End:           parseRequestParam("end", request, response),
+	})
 	if err != nil {
 		response.WriteError(http.StatusInternalServerError, err)
-		glog.Errorf("unable to get cluster metric: %s", err)
+		glog.Errorf("unable to get namespace metric: %s", err)
 		return
 	}
 	response.WriteEntity(exportTimeseries(timeseries, new_stamp))
@@ -191,22 +414,16 @@ func (a *Api) namespaceMetrics(request *restful.Request, response *restful.Respo
 func (a *Api) podMetrics(request *restful.Request, response *restful.Response) {
 	cluster := a.manager.GetCluster()
 
-	// Get namespace name
-	namespace := request.PathParameter("namespace-name")
-
-	// Get pod name
-	pod := request.PathParameter("pod-name")
-
-	// Get metric name
-	metric_name := request.PathParameter("metric-name")
-
-	// Get start time, parse as time.Time
-	req_stamp := parseRequestStartParam(request, response)
-
-	timeseries, new_stamp, err := cluster.GetPodMetric(namespace, pod, metric_name, req_stamp)
+	timeseries, new_stamp, err := cluster.GetPodMetric(model.PodRequest{
+		NamespaceName: request.PathParameter("namespace-name"),
+		PodName:       request.PathParameter("pod-name"),
+		MetricName:    request.PathParameter("metric-name"),
+		Start:         parseRequestParam("start", request, response),
+		End:           parseRequestParam("end", request, response),
+	})
 	if err != nil {
 		response.WriteError(http.StatusInternalServerError, err)
-		glog.Errorf("unable to get cluster metric: %s", err)
+		glog.Errorf("unable to get pod metric: %s", err)
 		return
 	}
 	response.WriteEntity(exportTimeseries(timeseries, new_stamp))
@@ -217,25 +434,17 @@ func (a *Api) podMetrics(request *restful.Request, response *restful.Response) {
 func (a *Api) podContainerMetrics(request *restful.Request, response *restful.Response) {
 	cluster := a.manager.GetCluster()
 
-	// Get namespace name
-	namespace := request.PathParameter("namespace-name")
-
-	// Get pod name
-	pod := request.PathParameter("pod-name")
-
-	// Get container name
-	container := request.PathParameter("container-name")
-
-	// Get metric name
-	metric_name := request.PathParameter("metric-name")
-
-	// Get start time, parse as time.Time
-	req_stamp := parseRequestStartParam(request, response)
-
-	timeseries, new_stamp, err := cluster.GetPodContainerMetric(namespace, pod, container, metric_name, req_stamp)
+	timeseries, new_stamp, err := cluster.GetPodContainerMetric(model.PodContainerRequest{
+		NamespaceName: request.PathParameter("namespace-name"),
+		PodName:       request.PathParameter("pod-name"),
+		ContainerName: request.PathParameter("container-name"),
+		MetricName:    request.PathParameter("metric-name"),
+		Start:         parseRequestParam("start", request, response),
+		End:           parseRequestParam("end", request, response),
+	})
 	if err != nil {
 		response.WriteError(http.StatusInternalServerError, err)
-		glog.Errorf("unable to get cluster metric: %s", err)
+		glog.Errorf("unable to get pod container metric: %s", err)
 		return
 	}
 	response.WriteEntity(exportTimeseries(timeseries, new_stamp))
@@ -246,32 +455,26 @@ func (a *Api) podContainerMetrics(request *restful.Request, response *restful.Re
 func (a *Api) freeContainerMetrics(request *restful.Request, response *restful.Response) {
 	cluster := a.manager.GetCluster()
 
-	// Get node name
-	node := request.PathParameter("node-name")
-
-	// Get container name
-	container := request.PathParameter("container-name")
-
-	// Get metric name
-	metric_name := request.PathParameter("metric-name")
-
-	// Get start time, parse as time.Time
-	req_stamp := parseRequestStartParam(request, response)
-
-	timeseries, new_stamp, err := cluster.GetFreeContainerMetric(node, container, metric_name, req_stamp)
+	timeseries, new_stamp, err := cluster.GetFreeContainerMetric(model.FreeContainerRequest{
+		NodeName:      request.PathParameter("node-name"),
+		ContainerName: request.PathParameter("container-name"),
+		MetricName:    request.PathParameter("metric-name"),
+		Start:         parseRequestParam("start", request, response),
+		End:           parseRequestParam("end", request, response),
+	})
 	if err != nil {
 		response.WriteError(http.StatusInternalServerError, err)
-		glog.Errorf("unable to get cluster metric: %s", err)
+		glog.Errorf("unable to get free container metric: %s", err)
 		return
 	}
 	response.WriteEntity(exportTimeseries(timeseries, new_stamp))
 }
 
-// parseRequestStartParam obtains the time.Time to be used as the start time during a model Get method.
-// parseRequestStartParam receives a request and a response as inputs, and returns the parsed time.
-func parseRequestStartParam(request *restful.Request, response *restful.Response) time.Time {
+// parseRequestParam parses a time.Time from a named QueryParam.
+// parseRequestParam receives a request and a response as inputs, and returns the parsed time.
+func parseRequestParam(param string, request *restful.Request, response *restful.Response) time.Time {
 	var err error
-	query_param := request.QueryParameter("start")
+	query_param := request.QueryParameter(param)
 	req_stamp := time.Time{}
 	if query_param != "" {
 		req_stamp, err = time.Parse(time.RFC3339, query_param)

--- a/model/impl_test.go
+++ b/model/impl_test.go
@@ -514,6 +514,7 @@ func TestUpdate(t *testing.T) {
 		source_cache = cacheFactory()
 		assert       = assert.New(t)
 		empty_cache  = cache.NewCache(24 * time.Hour)
+		zeroTime     = time.Time{}
 	)
 
 	// Invocation with empty cache
@@ -531,7 +532,7 @@ func TestUpdate(t *testing.T) {
 	assert.NotEmpty(cluster.Metrics)
 	assert.NotNil(cluster.Metrics[memWorking])
 	mem_work_ts := *(cluster.Metrics[memWorking])
-	actual := mem_work_ts.Get(time.Time{}, time.Time{})
+	actual := mem_work_ts.Get(zeroTime, zeroTime)
 	assert.Len(actual, 2)
 	// Datapoint present in both nodes, added up to 1024
 	assert.Equal(actual[0].Value.(uint64), uint64(1204))
@@ -540,7 +541,7 @@ func TestUpdate(t *testing.T) {
 
 	assert.NotNil(cluster.Metrics[memUsage])
 	mem_usage_ts := *(cluster.Metrics[memUsage])
-	actual = mem_usage_ts.Get(time.Time{}, time.Time{})
+	actual = mem_usage_ts.Get(zeroTime, zeroTime)
 	assert.Len(actual, 2)
 	// Datapoint present in both nodes, added up to 10000
 	assert.Equal(actual[0].Value.(uint64), uint64(10000))
@@ -550,7 +551,7 @@ func TestUpdate(t *testing.T) {
 	// Assert Kubernetes Metric aggregation up to namespaces
 	ns := cluster.Namespaces["test"]
 	mem_work_ts = *(ns.Metrics[memWorking])
-	actual = mem_work_ts.Get(time.Time{}, time.Time{})
+	actual = mem_work_ts.Get(zeroTime, zeroTime)
 	assert.Len(actual, 1)
 	assert.Equal(actual[0].Value.(uint64), uint64(1204))
 
@@ -569,118 +570,122 @@ func TestGetClusterMetric(t *testing.T) {
 		cluster      = newRealCluster(newTimeStore, time.Minute)
 		source_cache = cacheFactory()
 		assert       = assert.New(t)
+		zeroTime     = time.Time{}
 	)
 	// Invocation with no cluster metrics
-	res, stamp, err := cluster.GetClusterMetric(cpuUsage, time.Time{})
+	res, stamp, err := cluster.GetClusterMetric(ClusterRequest{cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Populate cluster
 	assert.NoError(cluster.Update(source_cache))
 
 	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetClusterMetric("doesnotexist", time.Time{})
+	res, stamp, err = cluster.GetClusterMetric(ClusterRequest{"doesnotexist", zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetClusterMetric(memUsage, time.Time{})
+	res, stamp, err = cluster.GetClusterMetric(ClusterRequest{memUsage, zeroTime, zeroTime})
 	assert.NoError(err)
-	assert.NotEqual(stamp, time.Time{})
+	assert.NotEqual(stamp, zeroTime)
 	assert.NotNil(res)
 }
 
 // TestGetNodeMetric tests all flows of GetNodeMetric.
 func TestGetNodeMetric(t *testing.T) {
 	var (
+		zeroTime     = time.Time{}
 		cluster      = newRealCluster(newTimeStore, time.Minute)
 		source_cache = cacheFactory()
 		assert       = assert.New(t)
 		hostname     = "hostname3"
 	)
 	// Invocation with no nodes in cluster
-	res, stamp, err := cluster.GetNodeMetric(hostname, cpuUsage, time.Time{})
+	res, stamp, err := cluster.GetNodeMetric(NodeRequest{hostname, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Populate cluster
 	assert.NoError(cluster.Update(source_cache))
 
 	// Invocation with non-existant node
-	res, stamp, err = cluster.GetNodeMetric("doesnotexist", cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetNodeMetric(NodeRequest{"doesnotexist", cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with new node - no metrics
 	cluster.addNode("newnode")
-	res, stamp, err = cluster.GetNodeMetric("newnode", cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetNodeMetric(NodeRequest{"newnode", cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetNodeMetric(hostname, "doesnotexist", time.Time{})
+	res, stamp, err = cluster.GetNodeMetric(NodeRequest{hostname, "doesnotexist", zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetNodeMetric(hostname, memUsage, time.Time{})
+	res, stamp, err = cluster.GetNodeMetric(NodeRequest{hostname, memUsage, zeroTime, zeroTime})
 	assert.NoError(err)
-	assert.NotEqual(stamp, time.Time{})
+	assert.NotEqual(stamp, zeroTime)
 	assert.NotNil(res)
 }
 
 // TestGetNamespaceMetric tests all flows of GetNamespaceMetric.
 func TestGetNamespaceMetric(t *testing.T) {
 	var (
+		zeroTime     = time.Time{}
 		cluster      = newRealCluster(newTimeStore, time.Minute)
 		source_cache = cacheFactory()
 		assert       = assert.New(t)
 		namespace    = "test"
 	)
 	// Invocation with no namespaces in cluster
-	res, stamp, err := cluster.GetNamespaceMetric(namespace, cpuUsage, time.Time{})
+	res, stamp, err := cluster.GetNamespaceMetric(NamespaceRequest{namespace, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Populate cluster
 	assert.NoError(cluster.Update(source_cache))
 
 	// Invocation with non-existant namespace
-	res, stamp, err = cluster.GetNamespaceMetric("doesnotexist", cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetNamespaceMetric(NamespaceRequest{"doesnotexist", cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with new namespace - no metrics
 	cluster.addNamespace("newnode")
-	res, stamp, err = cluster.GetNamespaceMetric("newnode", cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetNamespaceMetric(NamespaceRequest{"newnode", cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetNamespaceMetric(namespace, "doesnotexist", time.Time{})
+	res, stamp, err = cluster.GetNamespaceMetric(NamespaceRequest{namespace, "doesnotexist", zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetNamespaceMetric(namespace, memUsage, time.Time{})
+	res, stamp, err = cluster.GetNamespaceMetric(NamespaceRequest{namespace, memUsage, zeroTime, zeroTime})
 	assert.NoError(err)
-	assert.NotEqual(stamp, time.Time{})
+	assert.NotEqual(stamp, zeroTime)
 	assert.NotNil(res)
 }
 
 // TestGetPodMetric tests all flows of GetPodMetric.
 func TestGetPodMetric(t *testing.T) {
 	var (
+		zeroTime     = time.Time{}
 		cluster      = newRealCluster(newTimeStore, time.Minute)
 		source_cache = cacheFactory()
 		assert       = assert.New(t)
@@ -689,49 +694,50 @@ func TestGetPodMetric(t *testing.T) {
 		node         = "hostname2"
 	)
 	// Invocation with no namespaces in cluster
-	res, stamp, err := cluster.GetPodMetric(namespace, pod, cpuUsage, time.Time{})
+	res, stamp, err := cluster.GetPodMetric(PodRequest{namespace, pod, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Populate cluster
 	assert.NoError(cluster.Update(source_cache))
 
 	// Invocation with non-existant namespace
-	res, stamp, err = cluster.GetPodMetric("doesnotexist", pod, cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetPodMetric(PodRequest{"doesnotexist", pod, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with non-existant pod
-	res, stamp, err = cluster.GetPodMetric(namespace, "otherpod", cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetPodMetric(PodRequest{namespace, "otherpod", cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with new pod - no metrics
 	cluster.addPod(pod, "1234", cluster.Namespaces[namespace], cluster.Nodes[node])
-	res, stamp, err = cluster.GetPodMetric(namespace, pod, cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetPodMetric(PodRequest{namespace, pod, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetPodMetric(namespace, pod, "doesnotexist", time.Time{})
+	res, stamp, err = cluster.GetPodMetric(PodRequest{namespace, pod, "doesnotexist", zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetPodMetric(namespace, pod, memUsage, time.Time{})
+	res, stamp, err = cluster.GetPodMetric(PodRequest{namespace, pod, memUsage, zeroTime, zeroTime})
 	assert.NoError(err)
-	assert.NotEqual(stamp, time.Time{})
+	assert.NotEqual(stamp, zeroTime)
 	assert.NotNil(res)
 }
 
 // TestGetPodContainerMetric tests all flows of GetPodContainerMetric.
 func TestGetPodContainerMetric(t *testing.T) {
 	var (
+		zeroTime     = time.Time{}
 		cluster      = newRealCluster(newTimeStore, time.Minute)
 		source_cache = cacheFactory()
 		assert       = assert.New(t)
@@ -740,55 +746,56 @@ func TestGetPodContainerMetric(t *testing.T) {
 		container    = "container1"
 	)
 	// Invocation with no namespaces in cluster
-	res, stamp, err := cluster.GetPodContainerMetric(namespace, pod, container, cpuUsage, time.Time{})
+	res, stamp, err := cluster.GetPodContainerMetric(PodContainerRequest{namespace, pod, container, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Populate cluster
 	assert.NoError(cluster.Update(source_cache))
 
 	// Invocation with non-existant namespace
-	res, stamp, err = cluster.GetPodContainerMetric("doesnotexist", pod, container, cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{"doesnotexist", pod, container, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with new namespace - no metrics
 	cluster.addNamespace("newnode")
-	res, stamp, err = cluster.GetPodContainerMetric("newnode", pod, container, cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{"newnode", pod, container, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with non-existant pod
-	res, stamp, err = cluster.GetPodContainerMetric(namespace, "otherpod", container, cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{namespace, "otherpod", container, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with non-existant container
-	res, stamp, err = cluster.GetPodContainerMetric(namespace, pod, "doesnotexist", cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{namespace, pod, "doesnotexist", cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetPodContainerMetric(namespace, pod, container, "doesnotexist", time.Time{})
+	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{namespace, pod, container, "doesnotexist", zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetPodContainerMetric(namespace, pod, container, memUsage, time.Time{})
+	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{namespace, pod, container, memUsage, zeroTime, zeroTime})
 	assert.NoError(err)
-	assert.NotEqual(stamp, time.Time{})
+	assert.NotEqual(stamp, zeroTime)
 	assert.NotNil(res)
 }
 
 // TestGetFreeContainerMetric tests all flows of GetFreeContainerMetric.
 func TestGetFreeContainerMetric(t *testing.T) {
 	var (
+		zeroTime     = time.Time{}
 		cluster      = newRealCluster(newTimeStore, time.Minute)
 		source_cache = cacheFactory()
 		assert       = assert.New(t)
@@ -796,47 +803,158 @@ func TestGetFreeContainerMetric(t *testing.T) {
 		container    = "free_container1"
 	)
 	// Invocation with no nodes in cluster
-	res, stamp, err := cluster.GetFreeContainerMetric(node, container, cpuUsage, time.Time{})
+	res, stamp, err := cluster.GetFreeContainerMetric(FreeContainerRequest{node, container, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Populate cluster
 	assert.NoError(cluster.Update(source_cache))
 
 	// Invocation with non-existant node
-	res, stamp, err = cluster.GetFreeContainerMetric("doesnotexist", container, cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetFreeContainerMetric(FreeContainerRequest{"doesnotexist", container, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with new node - no metrics
 	cluster.addNode("newnode")
-	res, stamp, err = cluster.GetFreeContainerMetric("newnode", container, cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetFreeContainerMetric(FreeContainerRequest{"newnode", container, cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with non-existant container
-	res, stamp, err = cluster.GetFreeContainerMetric(node, "not_actual_ctr", cpuUsage, time.Time{})
+	res, stamp, err = cluster.GetFreeContainerMetric(FreeContainerRequest{node, "not_actual_ctr", cpuUsage, zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetFreeContainerMetric(node, container, "doesnotexist", time.Time{})
+	res, stamp, err = cluster.GetFreeContainerMetric(FreeContainerRequest{node, container, "doesnotexist", zeroTime, zeroTime})
 	assert.Error(err)
-	assert.Equal(stamp, time.Time{})
+	assert.Equal(stamp, zeroTime)
 	assert.Nil(res)
 
 	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetFreeContainerMetric(node, container, memUsage, time.Time{})
+	res, stamp, err = cluster.GetFreeContainerMetric(FreeContainerRequest{node, container, memUsage, zeroTime, zeroTime})
 	assert.NoError(err)
-	assert.NotEqual(stamp, time.Time{})
+	assert.NotEqual(stamp, zeroTime)
 	assert.NotNil(res)
 }
 
-// TestGetAvailableMetrics tests the flow of GetAvailableMetrics
+//TestGetNodes tests the flow of GetNodes.
+func TestGetNodes(t *testing.T) {
+	var (
+		cluster      = newRealCluster(newTimeStore, time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Invocation with empty cluster
+	res := cluster.GetNodes()
+	assert.Len(res, 0)
+
+	// Populate cluster
+	assert.NoError(cluster.Update(source_cache))
+
+	// Normal Invocation
+	res = cluster.GetNodes()
+	assert.Len(res, 2)
+}
+
+//TestGetNamespaces tests the flow of GetNamespaces.
+func TestGetNamespaces(t *testing.T) {
+	var (
+		cluster      = newRealCluster(newTimeStore, time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Invocation with empty cluster
+	res := cluster.GetNamespaces()
+	assert.Len(res, 0)
+
+	// Populate cluster
+	assert.NoError(cluster.Update(source_cache))
+
+	// Normal Invocation
+	res = cluster.GetNamespaces()
+	assert.Len(res, 1)
+}
+
+//TestGetPods tests the flow of GetPods.
+func TestGetPods(t *testing.T) {
+	var (
+		cluster      = newRealCluster(newTimeStore, time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Invocation with empty cluster
+	res := cluster.GetPods("test")
+	assert.Len(res, 0)
+
+	// Populate cluster
+	assert.NoError(cluster.Update(source_cache))
+
+	// Normal Invocation
+	res = cluster.GetPods("test")
+	assert.Len(res, 2)
+
+	// Invocation with non-existant namespace
+	res = cluster.GetPods("fakenamespace")
+	assert.Len(res, 0)
+}
+
+//TestGetPodContainers tests the flow of GetPodContainers.
+func TestGetPodContainers(t *testing.T) {
+	var (
+		cluster      = newRealCluster(newTimeStore, time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Invocation with empty cluster
+	res := cluster.GetPodContainers("test", "pod1")
+	assert.Len(res, 0)
+
+	// Populate cluster
+	assert.NoError(cluster.Update(source_cache))
+
+	// Normal Invocation
+	res = cluster.GetPodContainers("test", "pod1")
+	assert.Len(res, 2)
+
+	// Invocation with non-existant namespace
+	res = cluster.GetPodContainers("fail", "pod1")
+	assert.Len(res, 0)
+
+	// Invocation with non-existant pod
+	res = cluster.GetPodContainers("test", "pod5")
+	assert.Len(res, 0)
+}
+
+//TestGetFreeContainers tests the flow of GetFreeContainers.
+func TestGetFreeContainers(t *testing.T) {
+	var (
+		cluster      = newRealCluster(newTimeStore, time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Invocation with empty cluster
+	res := cluster.GetFreeContainers("hostname2")
+	assert.Len(res, 0)
+
+	// Populate cluster
+	assert.NoError(cluster.Update(source_cache))
+
+	// Normal Invocation
+	res = cluster.GetFreeContainers("hostname2")
+	assert.Len(res, 1)
+
+	// Invocation with non-existant node
+	res = cluster.GetFreeContainers("hostname9")
+	assert.Len(res, 0)
+}
+
+// TestGetAvailableMetrics tests the flow of GetAvailableMetrics.
 func TestGetAvailableMetrics(t *testing.T) {
 	var (
 		cluster      = newRealCluster(newTimeStore, time.Minute)
@@ -849,10 +967,8 @@ func TestGetAvailableMetrics(t *testing.T) {
 
 	// Populate cluster
 	assert.NoError(cluster.Update(source_cache))
-	// Populate cluster
-	assert.NoError(cluster.Update(cacheFactory()))
 
-	// Invocation with normal parameters
+	// Normal Invocation
 	res = cluster.GetAvailableMetrics()
 	assert.Len(res, 7)
 }
@@ -898,7 +1014,7 @@ func cmeFactory() *cache.ContainerMetricElement {
 		HasFilesystem: true,
 		HasDiskIo:     true,
 	}
-	containerSpec.Cpu.Limit = 1024
+	containerSpec.Cpu.Limit = 1000
 	containerSpec.Memory.Limit = 10000000
 
 	// Create a fuzzed ContainerStats struct

--- a/model/util.go
+++ b/model/util.go
@@ -145,7 +145,8 @@ func instantFromCumulativeMetric(value uint64, stamp time.Time, prev *store.Time
 	if tdelta == 0 {
 		return uint64(0), fmt.Errorf("cumulative metric timestamps are identical")
 	}
-	vdelta := (value - prev.Value.(uint64)) * 1024
+	// Divide metric by nanoseconds that have elapsed, multiply by 1000 to get an unsigned metric
+	vdelta := (value - prev.Value.(uint64)) * 1000
 
 	instaVal := vdelta / tdelta
 	prev.Value = value

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -265,12 +265,12 @@ func TestInstantFromCumulativeMetric(t *testing.T) {
 	// Invocation with regular arguments
 	val, err = instantFromCumulativeMetric(new_value, afterNow, oldTP)
 	assert.NoError(err)
-	assert.Equal(val, 513*1024)
+	assert.Equal(val, 513*1000)
 
 	// Second Invocation with regular arguments, prev TP has changed
 	newerVal := uint64(15900000000000)
 	val, err = instantFromCumulativeMetric(newerVal, afterNow.Add(time.Second), oldTP)
 	assert.NoError(err)
-	assert.Equal(val, 510*1024)
+	assert.Equal(val, 510*1000)
 
 }


### PR DESCRIPTION
This is #420, reopened due to jenkins testing the wrong PR.

This PR is focused in 2 major changes to the model REST API:

Model GetXMetric methods now receive specific Request structs as parameters.
Added new Getters, endpoints and tests for extracting all nodes, namespaces, pods and containers from the model. This should allow API consumers to seamlessly