### PR TITLE
Remove redundant :'' from sources without url

### DIFF
--- a/deploy/kube-config/google/heapster-controller.json
+++ b/deploy/kube-config/google/heapster-controller.json
@@ -30,7 +30,7 @@
 			"name": "heapster",
 			"command": [
 			    "/heapster",
-			    "--source=kubernetes:''",
+			    "--source=kubernetes",
 			    "--sink=gcm",
 			    "--sink=gcl",
 			    "--poll_duration=2m",

--- a/deploy/kube-config/influxdb/heapster-controller.json
+++ b/deploy/kube-config/influxdb/heapster-controller.json
@@ -30,7 +30,7 @@
 			"name": "heapster",
 			"command": [
 			    "/heapster",
-			    "--source=kubernetes:''",
+			    "--source=kubernetes",
 			    "--sink=influxdb:http://monitoring-influxdb:80"
 			]
 		    }

--- a/deploy/kube-config/standalone/heapster-controller.json
+++ b/deploy/kube-config/standalone/heapster-controller.json
@@ -30,7 +30,7 @@
 			"name": "heapster",
 			"command": [
 			    "/heapster",
-			    "--source=kubernetes:''"
+			    "--source=kubernetes"
 			]
 		    }
 		]


### PR DESCRIPTION
It's effectively the same thing, just more confusing.