### PR TITLE
Fix nil dereference panic in cache_impl_test

### DIFF
--- a/sinks/cache/cache_impl_test.go
+++ b/sinks/cache/cache_impl_test.go
@@ -128,6 +128,9 @@ func TestRealCacheData(t *testing.T) {
 	for _, expectedPod := range pods {
 		pod, exists := actualPodsMap[expectedPod.Name]
 		require.True(t, exists)
+		if pod == nil {
+			continue
+		}
 		require.NotEmpty(t, pod.Containers)
 		assert.NotEmpty(pod.Containers[0].Metrics)
 	}
@@ -138,6 +141,9 @@ func TestRealCacheData(t *testing.T) {
 	for _, expectedContainer := range containers {
 		ce, exists := actualContainerMap[expectedContainer.Name]
 		assert.True(exists)
+		if ce == nil {
+			continue
+		}
 		assert.True("gcr.io/"+expectedContainer.Name == ce.Image)
 		assert.NotNil(ce.Metrics)
 		assert.NotEmpty(ce.Metrics)


### PR DESCRIPTION
Occured in travis:

https://travis-ci.org/GoogleCloudPlatform/heapster/builds/74985112

```
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a ./...
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a
hooks/coverage.sh
?   	k8s.io/heapster	[no test files]
?   	k8s.io/heapster/api/v1	[no test files]
?   	k8s.io/heapster/clusters/coreos	[no test files]
?   	k8s.io/heapster/extpoints	[no test files]
ok  	k8s.io/heapster/integration	0.014s	coverage: 0.0% of statements
ok  	k8s.io/heapster/manager	0.011s	coverage: 22.4% of statements
ok  	k8s.io/heapster/model	0.033s	coverage: 96.6% of statements
ok  	k8s.io/heapster/sinks	0.013s	coverage: 31.2% of statements
ok  	k8s.io/heapster/sinks/api	0.019s	coverage: 98.2% of statements
ok  	k8s.io/heapster/sinks/api/v1	0.011s	coverage: 70.2% of statements
--- FAIL: TestRealCacheData-2 (0.01s)
	assertions.go:154: 
                        
	Location:	cache_impl_test.go:140
		
	Error:		Should be true
		

panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x467882]

goroutine 12 [running]:
testing.func·006()
	/usr/local/go/src/testing/testing.go:441 +0x181
k8s.io/heapster/sinks/cache.TestRealCacheData(0xc20904c990)
	/home/travis/gopath/src/k8s.io/heapster/sinks/cache/cache_impl_test.go:141 +0xe52
testing.tRunner(0xc20904c990, 0xd021b0)
	/usr/local/go/src/testing/testing.go:447 +0xbf
created by testing.RunTests
	/usr/local/go/src/testing/testing.go:555 +0xa8b

goroutine 1 [chan receive]:
testing.RunTests(0x9b4580, 0xd02180, 0x4, 0x4, 0xc208087001)
	/usr/local/go/src/testing/testing.go:556 +0xad6
testing.(*M).Run(0xc20800b860, 0xd25f60)
	/usr/local/go/src/testing/testing.go:485 +0x6c
main.main()
	k8s.io/heapster/sinks/cache/_test/_testmain.go:106 +0x291

goroutine 5 [chan receive]:
github.com/golang/glog.(*loggingT).flushDaemon(0xd1dac0)
	/home/travis/gopath/src/k8s.io/heapster/Godeps/_workspace/src/github.com/golang/glog/glog.go:879 +0x78
created by github.com/golang/glog.init·1
	/home/travis/gopath/src/k8s.io/heapster/Godeps/_workspace/src/github.com/golang/glog/glog.go:410 +0x2a7

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:2232 +0x1

goroutine 11 [sleep]:
github.com/GoogleCloudPlatform/kubernetes/pkg/util.Until(0xc208108020, 0x3b9aca00, 0xc208086420)
	/home/travis/gopath/src/k8s.io/heapster/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/util.go:114 +0x98
created by k8s.io/heapster/sinks/cache.NewCache
	k8s.io/heapster/sinks/cache/_test/_obj_test/cache_impl.go:388 +0x2d2

goroutine 20 [sleep]:
github.com/GoogleCloudPlatform/kubernetes/pkg/util.Until(0xc2087ac130, 0x3b9aca00, 0xc208086420)
	/home/travis/gopath/src/k8s.io/heapster/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/util.go:114 +0x98
created by k8s.io/heapster/sinks/cache.NewCache
	k8s.io/heapster/sinks/cache/_test/_obj_test/cache_impl.go:388 +0x2d2

goroutine 13 [sleep]:
github.com/GoogleCloudPlatform/kubernetes/pkg/util.Until(0xc208fba080, 0x34630b8a000, 0xc208086420)
	/home/travis/gopath/src/k8s.io/heapster/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/util.go:114 +0x98
created by k8s.io/heapster/sinks/cache.NewCache
	k8s.io/heapster/sinks/cache/_test/_obj_test/cache_impl.go:388 +0x2d2
FAIL	k8s.io/heapster/sinks/cache	15.447s
godep: go exit status 1
make: *** [test-unit-cov] Error 1
```